### PR TITLE
REDDEV-351 external module

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,10 +1,12 @@
 # Vizr Implementation Details
 
-Vizr is a plugin for REDCap that allows users to visualize and group aggregated data over time. PHP is used to communicate with the REDCap plugin API and database, but most of the logic exists client-side in Javascript files. The point of entry to the plugin is the `index.php` file in the vizr-plugin directory. This creates the outer containers to hold the charts and instructions, then calls the `Vizr.run()` method on document.ready() to populate the rest of the DOM elements.
+Vizr is an external module for REDCap that allows users to visualize and group aggregated data over time. PHP is used to communicate with the REDCap external module API and database, but most of the logic exists client-side in Javascript files. The point of entry to the external module is the `index.php` file in the vizr_vX.Y.Z directory where X.Y.Z is the version. This creates the outer containers to hold the charts and instructions, then calls the `Vizr.run()` method on document.ready() to populate the rest of the DOM elements.
 
 ## Storage
 
-REDCap does not support additional storage for plugins. To circumvent this, Vizr requires an additional REDCap project to store chart configuration. A single project for the site's REDCap instance will be configured by the administrator. (See installation instructions in vizr-plugin/README.md.)
+TODO: Update these instructions once the Vizr external module uses native persistence.
+
+REDCap does not support additional storage for plugins. To circumvent this, Vizr requires an additional REDCap project to store chart configuration. A single project for the site's REDCap instance will be configured by the administrator. (See installation instructions in [INSTALL.md](INSTALL.md).)
 
 ## PHP Service Layer
 
@@ -21,7 +23,7 @@ persist.php | Save chart definitions to the configuration project
 
 The most complex logic at the service layer is in `data.php`. This file takes a number of inputs and must be able to retrieve and interpret data from both nonlongitudinal and longitudinal studies.
 
-Among the inputs passed in is a filter. This is a string provided by the user that should conform to REDCap syntax. It is treated as a black box. Vizr simply pushes it to the REDCap plugin API, and unexpected data may not be properly handled. If the input is bad, the filter may be ignored or the plugin API may simply crash. In the event of a crash, Vizr displays a message that the chart could not be rendered.
+Among the inputs passed in is a filter. This is a string provided by the user that should conform to REDCap syntax. It is treated as a black box. Vizr simply pushes it to the REDCap external module API, and unexpected data may not be properly handled. If the input is bad, the filter may be ignored or the external module API may simply crash. In the event of a crash, Vizr displays a message that the chart could not be rendered.
 
 A successful response should contain an object with two components - the `data` and optionally a list of `filterEvents`. For a nonlongitudinal project, only `data` will exist, and the structure would look something like this:
 
@@ -42,7 +44,7 @@ For longitudinal projects where data may be collected multiple times and at diff
 
 When a user configures a chart, they may be seeking information about up to 3 events. Both the data and group fields must have an associated event, and the UI provides selection components for these. In addition, the filter may or may not contain event information. (e.g., `[visit_1_arm_1][visit_status]='1'`).
 
-Because the filter is treated as a black box, the first step in processing a longitudinal data request is to simply apply the filter and get the record ids and events associated with that filter. Depending on whether the filter includes an event, the plugin API would return something like this:
+Because the filter is treated as a black box, the first step in processing a longitudinal data request is to simply apply the filter and get the record ids and events associated with that filter. Depending on whether the filter includes an event, the external module API would return something like this:
 
 ```
 Filter: [visit_1_arm_1][visit_status]='1' (Return all record ids where visit 1 is complete)
@@ -63,7 +65,7 @@ Filter: [visit_status]='1' (Return all record ids where ANY visit is complete)
 ```
 The second example illustrates some of the complexity. The same record may be returned more than once for each matching event. Rather than make assumptions about the user's intent, `data.php` will return all of the rows retrieved from the filter back to the Javascript for processing. The UI will aggregate the data returned and present a select box for live filtering of the data based on event.
 
-Before this can happen, though, `data.php` must perform some transformations. At this point, only the filter has been applied and only the set of record ids and events have been retrieved. It also needs to process the other inputs - retrieving the data and group fields from their respective events. An additional call is made to the plugin API to get this data only for the record ids returned from the filter.
+Before this can happen, though, `data.php` must perform some transformations. At this point, only the filter has been applied and only the set of record ids and events have been retrieved. It also needs to process the other inputs - retrieving the data and group fields from their respective events. An additional call is made to the external module API to get this data only for the record ids returned from the filter.
 
 Depending on whether the data and group fields were in the same event, the API would return something like this:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,29 +1,64 @@
 # Vizr Installation
 
-The Vizr plugin consists of a JavaScript file and a few PHP service files that can be installed in
-REDCap using the following instructions.
+The Vizr external module consists of JavaScript and a few PHP service files that can be installed
+using the following instructions.
 
-## Install the plugin
-1. Extract the `vizr-plugin.zip` file.
-2. Place the `vizr-plugin` directory in the `redcap/plugins` directory.
-3. Ensure that the web server has permission to read the files. For example with some Linux systems:
+## Install the Vizr external module
+
+1. Extract the `vizr_vX.Y.Z.zip` file where X.Y.Z is the current release version.
+2. Place the `vizr_vX.Y.Z` directory in the `redcap/modules` directory.
+3. Ensure that the web server has permission to read the files. For example with some
+Linux systems:
+
 ```
-sudo chown apache:apache -R redcap/plugins/vizr-plugin
-sudo chmod 440 -R redcap/plugins/vizr-plugin
+sudo chown apache:apache -R redcap/modules/vizr_vX.Y.Z
+sudo chmod 440 -R redcap/modules/vizr_vX.Y.Z
 ```
 
 ## Create a Vizr config project
-Create a new REDCap project using the provided data dictionary.
+
+Vizr needs to save information about the charts that have been configured in each REDCap
+project so they can be retrieved and displayed to other users. This data will be stored in
+its own project in REDCap. Create a new REDCap project either using the provided REDCap
+project XML file, `VizrConfigurationProject.xml`, or by uploading the data dictionary,
+`VizrConfigurationProject_DataDictionary.csv`.
+
+***Take note of the project id number as it will be needed to configure Vizr in the next
+step.***
 
 ## Configure Vizr
-Rename the `example_config.php` file in the vizr-plugin directory to `config.php` and edit it,
-adding the project number of the previously created create project.
+
+Rename the `example_config.php` file in the vizr_vX.Y.Z directory to `config.php` and edit
+it, adding the project number of the previously created configuration project.
+
+```
+$config_project_id = <Vizr config project id>;
+```
 
 ## Add Vizr to a project
-In an existing project add a Bookmark for the vizr-plugin with the following configuration:
 
-* **Link URL/Destination:** `/redcap/plugins/vizr-plugin/index.php`
-* **Link Type:** Simple Link
-* **User Access:** Only users that have "Project Setup and Design rights"
-  can create or modify Vizr charts. Granting access to all users should be fine.
-* **Append project id to URL:** Checked
+Enable the module in REDCap. You can enable it for all projects, or on a per-project basis. The instructions below assume a per-project setup.
+
+1. Go to "Control Center" and then "External Modules".
+2. Click "Enable a module". Select the version you just installed.
+
+Enable Vizr for your project.
+
+1. Go to your project and then "External Modules" on the left navigation bar.
+2. Click "Enable a module" and enable the Vizr external module.
+
+You should now have a section on the left of your project named "External Modules" with a link to Vizr.
+
+# Upgrading Vizr
+
+To upgrade Vizr, follow the same steps for installing Vizr. Each version of Vizr will have it's own directory in `redcap/modules` distinguished by a version number. Once the new version is added to REDCap follow the same steps for adding Vizr to a project and enable the new version.
+
+You may want to copy your previous `config.php` into the new version. Check the latest `example_config.php` to make sure there are no new properties that would need to be added.
+
+## Verifying the upgrade
+
+To verify the installation, view the Vizr charts for a project. A message should display
+below the charts that says "REDCap Vizr" and a version number. The version should match
+the one listed in the name of the Vizr zip file. For example, for a zip file named
+`vizr_v1.0.3.zip`, the message should be "REDCap Vizr 1.0.3."
+

--- a/README.md
+++ b/README.md
@@ -1,69 +1,12 @@
-# Vizr Plugin
+# Vizr External Module
 
 Vizr was created by the Oregon Clinical & Translational Research Institute's (OCTRI)
 Clinical Research Informatics (CRI) Application team at Oregon Health & Science University
 (OHSU) with the aim to visualize data contained within a REDCap project.
 
-This plugin provides a way for project designers to create charts summarizing their data
+This external module provides a way for project designers to create charts summarizing their data
 in a time series fashion to provide additional insights about their project.
 
-# Vizr Installation
+# Vizr Installation and Upgrades
 
-The Vizr plugin consists of JavaScript and a few PHP service files that can be installed
-using the following instructions.
-
-## Install the plugin
-
-1. Extract the `vizr-plugin.zip` file.
-2. Place the `vizr-plugin` directory in the `redcap/plugins` directory.
-3. Ensure that the web server has permission to read the files. For example with some
-Linux systems:
-
-```
-sudo chown apache:apache -R redcap/plugins/vizr-plugin
-sudo chmod 440 -R redcap/plugins/vizr-plugin
-```
-
-## Create a Vizr config project
-
-Vizr needs to save information about the charts that have been configured in each REDCap
-project so they can be retrieved and displayed to other users. This data will be stored in
-its own project in REDCap. Create a new REDCap project either using the provided REDCap
-project XML file, `VizrConfigurationProject.xml`, or by uploading the data dictionary,
-`VizrConfigurationProject_DataDictionary.csv`.
-
-***Take note of the project id number as it will be needed to configure Vizr in the next
-step.***
-
-## Configure Vizr
-
-Rename the `example_config.php` file in the vizr-plugin directory to `config.php` and edit
-it, adding the project number of the previously created configuration project.
-
-```
-$config_project_id = <Vizr config project id>;
-```
-
-## Add Vizr to a project
-
-In an existing project add a Bookmark for the vizr-plugin with the following configuration:
-
-**Link URL/Destination:** `/redcap/plugins/vizr-plugin/index.php`
-**Link Type:** Simple Link
-**Append project id to URL:** Checked
-
-# Upgrading Vizr
-
-To upgrade Vizr, you should replace the `lib` directory.
-
-1. Extract the `vizr-plugin.zip` file.
-2. Copy the `lib` directory from the zip file into the `redcap/plugins/vizr-plugin`
-directory. This replaces the old `lib` directory with a new version of the `lib` directory.
-3. Ensure that the web server has permission to see the files, as described above.
-
-## Verifying the upgrade
-
-To verify the installation, view the Vizr charts for a project. A message should display
-below the charts that says "REDCap Vizr" and a version number. The version should match
-the one listed in the name of the Vizr zip file. For example, for a zip file named
-`vizr-plugin-1.0.3.zip`, the message should be "REDCap Vizr 1.0.3."
+See [INSTALL.md](INSTALL.md).

--- a/Vizr.php
+++ b/Vizr.php
@@ -1,0 +1,9 @@
+<?php
+namespace Octri\Vizr;
+
+use ExternalModules\AbstractExternalModule;
+use ExternalModules\ExternalModules;
+
+class Vizr extends AbstractExternalModule {
+
+}

--- a/config.json
+++ b/config.json
@@ -4,8 +4,28 @@
   "description": "Vizr was created by the Oregon Clinical & Translational Research Institute's (OCTRI) Clinical Research Informatics (CRI) Application team at Oregon Health & Science University (OHSU) with the aim to visualize data contained within a REDCap project.",
   "authors": [
     {
-      "name": "Devs",
-      "email": "criapps@ohsu.edu",
+      "name": "Erik Benton",
+      "email": "benton@ohsu.edu",
+      "institution": "OHSU"
+    },
+    {
+      "name": "Heath Harrelson",
+      "email": "harrelst@ohsu.edu",
+      "institution": "OHSU"
+    },
+    {
+      "name": "Matthew Lawhead",
+      "email": "lawhead@ohsu.edu",
+      "institution": "OHSU"
+    },
+    {
+      "name": "Weldon Sams ",
+      "email": "sams@ohsu.edu",
+      "institution": "OHSU"
+    },
+    {
+      "name": "Amy Yates",
+      "email": "yateam@ohsu.edu",
       "institution": "OHSU"
     }
   ],
@@ -22,4 +42,3 @@
     ]
   }
 }
-

--- a/config.json
+++ b/config.json
@@ -1,0 +1,25 @@
+{
+  "name": "REDCap Vizr",
+  "namespace": "Octri\\Vizr",
+  "description": "Vizr was created by the Oregon Clinical & Translational Research Institute's (OCTRI) Clinical Research Informatics (CRI) Application team at Oregon Health & Science University (OHSU) with the aim to visualize data contained within a REDCap project.",
+  "authors": [
+    {
+      "name": "Devs",
+      "email": "criapps@ohsu.edu",
+      "institution": "OHSU"
+    }
+  ],
+  "permissions": [
+    "select_data"
+  ],
+  "links": {
+    "project": [
+      {
+        "name": "Vizr",
+        "icon": "brick",
+        "url": "index.php"
+      }
+    ]
+  }
+}
+

--- a/example_config.php
+++ b/example_config.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * PLUGIN NAME: REDCap Vizr
- * DESCRIPTION: Configuration file for the Vizr plugin. This file is included in other Vizr php
+ * EXTERNAL MODULE: REDCap Vizr
+ * DESCRIPTION: Configuration file for the Vizr external module. This file is included in other Vizr php
  * files to retrieve the REDCap project that holds the chart definition data.
  */
 

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PLUGIN NAME: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION:
  */
 

--- a/index.php
+++ b/index.php
@@ -4,4 +4,4 @@
  * DESCRIPTION:
  */
 
-require_once "./lib/main.php";
+require_once dirname(realpath(__FILE__)) . '/lib/main.php';

--- a/js/main.js
+++ b/js/main.js
@@ -428,7 +428,6 @@ function persistConfig(config) {
  * @return {Object} the recordIdField, dataDictionary, and events for the current project
  */
 function getMetadata(pid) {
-  console.log(`${endpointUrls['lib/metadata.php']}`);
   return $.ajax({
     url: `${endpointUrls['lib/metadata.php']}`,
     method: "GET"

--- a/js/main.js
+++ b/js/main.js
@@ -37,6 +37,8 @@ const messages = {
   }
 };
 
+let endpointUrls = {};
+
 /**
  * Shows more detailed instructions and an example chart if no charts are configured,
  * otherwise hides most documentation.
@@ -412,7 +414,7 @@ function persistConfig(config) {
   let json = JSON.stringify(config.charts);
   json = json.replace(/\\"/g,'\\\\"');
   return $.ajax({
-    url: `lib/persist.php?pid=${config.pid}`,
+    url: `${endpointUrls['lib/persist.php']}`,
     data: { "charts": json },
     method: "POST"
   });
@@ -426,8 +428,9 @@ function persistConfig(config) {
  * @return {Object} the recordIdField, dataDictionary, and events for the current project
  */
 function getMetadata(pid) {
+  console.log(`${endpointUrls['lib/metadata.php']}`);
   return $.ajax({
-    url: `lib/metadata.php?pid=${pid}`,
+    url: `${endpointUrls['lib/metadata.php']}`,
     method: "GET"
   });
 }
@@ -445,7 +448,7 @@ function getMetadata(pid) {
  */
 function getChartData(config, container, chartDef, recordIdField) {
   $.ajax({
-    url: `lib/data.php?pid=${config.pid}`,
+    url: `${endpointUrls['lib/data.php']}`,
     data: {
       "recordIdField": recordIdField,
       "filter": chartDef.filter,
@@ -587,7 +590,7 @@ function filterByEventSelection(data, selection) {
  */
 function queryChartDefs(pid) {
   return $.ajax({
-    url: `lib/chart_defs.php?pid=${pid}`,
+    url: `${endpointUrls['lib/chart_defs.php']}`,
     method: "GET"
   });
 }
@@ -647,7 +650,8 @@ function vizrVersion() {
  * @param {Boolean} canEdit - boolean indicating whether or not the links should display to
  *   create or edit charts.
  */
-export function run(pid, canEdit) {
+export function run(pid, canEdit, jsonEndpointUrls) {
+  endpointUrls = JSON.parse(jsonEndpointUrls);
   getMetadata(pid).then(metadata => {
     config(pid, canEdit).then(config => {
 

--- a/lib/chart_defs.php
+++ b/lib/chart_defs.php
@@ -9,11 +9,12 @@
 header('Content-Type: application/json');
 
 // Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
-require_once "../../../redcap_connect.php";
+require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 
 $defs_object = new stdClass();
 $error_message = "The Vizr plugin is not configured in your REDCap instance. Contact your REDCap administrator.";
-if (!@include "../config.php") {
+
+if (!@include dirname(realpath(__FILE__)) . '/../config.php') {
   $defs_object->error = $error_message;
 } else if ($config_project_id == -1) {
   $defs_object->error = $error_message;

--- a/lib/chart_defs.php
+++ b/lib/chart_defs.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PLUGIN: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION: Queries the VIZR configuration project for chart definition data for the current
  *  project. The $config_project_id parameter is specified in config.php. If config.php does not
  *  exist or the id is the default, return {error : "..."}. Otherwise, return
@@ -12,7 +12,7 @@ header('Content-Type: application/json');
 require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 
 $defs_object = new stdClass();
-$error_message = "The Vizr plugin is not configured in your REDCap instance. Contact your REDCap administrator.";
+$error_message = "The Vizr external module is not configured in your REDCap instance. Contact your REDCap administrator.";
 
 if (!@include dirname(realpath(__FILE__)) . '/../config.php') {
   $defs_object->error = $error_message;

--- a/lib/data.php
+++ b/lib/data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PLUGIN: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION: Queries the current project for data, which is then summarized by Vizr to create
  * a chart. pid must be appended to the query url for this to be treated as a project-level request
  * POST data should contain the following:

--- a/lib/data.php
+++ b/lib/data.php
@@ -36,7 +36,7 @@
 header('Content-Type: application/json');
 
 // Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
-require_once "../../../redcap_connect.php";
+require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 
 /**
  * Filter the input

--- a/lib/main.tmpl
+++ b/lib/main.tmpl
@@ -1,6 +1,6 @@
 <?php
 /**
- * PLUGIN NAME: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION:
  */
 

--- a/lib/main.tmpl
+++ b/lib/main.tmpl
@@ -9,12 +9,37 @@
  * relative to the parent directory.
  */
 
+ // If noAuth is true, NOAUTH will be appended to the URL. The page will be public.
+$noAuth = false;
+// If true, the URL will be in the API format and will not include the REDCap version in the URL.
+$useApiEndpoint = true;
+
 // Call the REDCap Connect file in the main "redcap" directory
-require_once "../../redcap_connect.php";
-require_once "permissions.php";
+require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
+require_once dirname(realpath(__FILE__)) . '/permissions.php';
 
 // Display the project header
 require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
+
+$jsHashedFiles = array();
+<% for (var file in htmlWebpackPlugin.files.js) { %>
+$jsHashedFiles[] = '<%= htmlWebpackPlugin.files.js[file].slice(3) %>';
+<% } %>
+
+$jsUrls = array_map(function($asset) {
+  global $module, $noAuth, $useApiEndpoint;
+  return $module->getUrl($asset, $noAuth, $useApiEndpoint);
+}, $jsHashedFiles);
+
+$cssHashedFiles = array();
+<% for (var css in htmlWebpackPlugin.files.css) { %>
+$cssHashedFiles[] = '<%= htmlWebpackPlugin.files.css[css].slice(3) %>';
+<% } %>
+
+$cssUrls = array_map(function($asset) {
+  global $module, $noAuth, $useApiEndpoint;
+  return $module->getUrl($asset, $noAuth, $useApiEndpoint);
+}, $cssHashedFiles);
 ?>
 
 <div class="vizr-container">
@@ -26,14 +51,20 @@ require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
   </div>
 </div>
 
-<% for (var file in htmlWebpackPlugin.files.js) { %>
-<script src="<%= htmlWebpackPlugin.files.js[file].slice(3) %>"></script>
-<% } %>
+<?php
+print(implode("\n", array_map(function($jsUrl) {
+  return "<script src=\"{$jsUrl}\"></script>";
+}, $jsUrls)));
+?>
+
 <script type="text/javascript">
 $(document).ready(function(){
-  <% for (var css in htmlWebpackPlugin.files.css) { %>
-  $('head').append('<link href="<%= htmlWebpackPlugin.files.css[css].slice(3) %>" rel="stylesheet">');
-  <% } %>
+  <?php
+  print(implode("\n", array_map(function($cssUrl) {
+    return "$('head').append('<link href=\"{$cssUrl}\" rel=\"stylesheet\">');";
+  }, $cssUrls)));
+  ?>
+
   Vizr.run(<?php echo $project_id ?>, <?php echo ($can_edit ? "true" : "false") ?>);
 });
 </script>

--- a/lib/main.tmpl
+++ b/lib/main.tmpl
@@ -21,25 +21,35 @@ require_once dirname(realpath(__FILE__)) . '/permissions.php';
 // Display the project header
 require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 
-$jsHashedFiles = array();
+$jsFileNames = array();
 <% for (var file in htmlWebpackPlugin.files.js) { %>
-$jsHashedFiles[] = '<%= htmlWebpackPlugin.files.js[file].slice(3) %>';
+$jsFileNames[] = '<%= htmlWebpackPlugin.files.js[file].slice(3) %>';
 <% } %>
 
 $jsUrls = array_map(function($asset) {
   global $module, $noAuth, $useApiEndpoint;
   return $module->getUrl($asset, $noAuth, $useApiEndpoint);
-}, $jsHashedFiles);
+}, $jsFileNames);
 
-$cssHashedFiles = array();
+$cssFileNames = array();
 <% for (var css in htmlWebpackPlugin.files.css) { %>
-$cssHashedFiles[] = '<%= htmlWebpackPlugin.files.css[css].slice(3) %>';
+$cssFileNames[] = '<%= htmlWebpackPlugin.files.css[css].slice(3) %>';
 <% } %>
 
 $cssUrls = array_map(function($asset) {
   global $module, $noAuth, $useApiEndpoint;
   return $module->getUrl($asset, $noAuth, $useApiEndpoint);
-}, $cssHashedFiles);
+}, $cssFileNames);
+
+// Construct a JSON object where the key is like `lib/data.php` and the value is the corresponding external module URL.
+$libFilePaths = glob(dirname(realpath(__FILE__)) . '/*.php');
+$endpointUrls = array();
+foreach ($libFilePaths as $libFilePath) {
+  $relFilePath = str_replace(dirname(realpath(__FILE__)), 'lib', $libFilePath);
+  $endpointUrls[$relFilePath] = $module->getUrl($relFilePath, $noAuth, $useApiEndpoint);
+}
+
+$jsonEndpointUrls = json_encode($endpointUrls);
 ?>
 
 <div class="vizr-container">
@@ -52,7 +62,7 @@ $cssUrls = array_map(function($asset) {
 </div>
 
 <?php
-print(implode("\n", array_map(function($jsUrl) {
+echo(implode("\n", array_map(function($jsUrl) {
   return "<script src=\"{$jsUrl}\"></script>";
 }, $jsUrls)));
 ?>
@@ -60,12 +70,12 @@ print(implode("\n", array_map(function($jsUrl) {
 <script type="text/javascript">
 $(document).ready(function(){
   <?php
-  print(implode("\n", array_map(function($cssUrl) {
+  echo(implode("\n", array_map(function($cssUrl) {
     return "$('head').append('<link href=\"{$cssUrl}\" rel=\"stylesheet\">');";
   }, $cssUrls)));
   ?>
 
-  Vizr.run(<?php echo $project_id ?>, <?php echo ($can_edit ? "true" : "false") ?>);
+  Vizr.run(<?php echo $project_id ?>, <?php echo ($can_edit ? "true" : "false") ?>, '<?php echo $jsonEndpointUrls ?>');
 });
 </script>
 

--- a/lib/metadata.php
+++ b/lib/metadata.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PLUGIN: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION: Queries the current project for the record id field and data dictionary.
  *  Also gets events and related forms if the project is longitudinal. Returns a mapping
  *  in json format like:

--- a/lib/metadata.php
+++ b/lib/metadata.php
@@ -18,7 +18,7 @@
 header('Content-Type: application/json');
 
 // Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
-require_once "../../../redcap_connect.php";
+require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 
 $metadata_object = new stdClass();
 $record_id_field = REDCap::getRecordIdField();

--- a/lib/permissions.php
+++ b/lib/permissions.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * PLUGIN NAME: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION: Sets variables indicating whether or not the current user has
- * edit permissions to the Vizr plugin in the current project.
+ * edit permissions to the Vizr external module in the current project.
  */
 // NOTE: The following line should be included in the calling page.
 // require_once "../../../redcap_connect.php";

--- a/lib/persist.php
+++ b/lib/persist.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PLUGIN: REDCap Vizr
+ * EXTERNAL MODULE: REDCap Vizr
  * DESCRIPTION: Persists chart configuration data for the current project in the VIZR configuration
  *  project. The $config_project_id parameter is specified in config.php. This functionality is
  *  only available for users with the 'Project Design and Setup' rights for the current project.

--- a/lib/persist.php
+++ b/lib/persist.php
@@ -7,9 +7,9 @@
  */
 
 // Call the REDCap Connect file in the main "redcap" directory
-require_once "../../../redcap_connect.php";
-require_once "../config.php";
-require_once "permissions.php";
+require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
+require_once dirname(realpath(__FILE__)) . '/../config.php';
+require_once dirname(realpath(__FILE__)) . '/permissions.php';
 
 // pid in query ensures that the user has access to this project; this is also required for the
 // REDCap::getUserRights() call.

--- a/lib/vizr.css
+++ b/lib/vizr.css
@@ -1,5 +1,5 @@
 /*
-  Styles for the REDCap Vizr plugin
+  Styles for the REDCap Vizr external module
 */
 .vizr-form-panel {
 	width:600px;

--- a/test/example-ajax-responses.js
+++ b/test/example-ajax-responses.js
@@ -25,7 +25,7 @@ export const exampleResponses = {
     unconfigured: {
       status: 200,
       contentType: 'application/json',
-      responseText: '{"error": "The plugin is not configured"}'
+      responseText: '{"error": "The external module is not configured"}'
     },
     noChartDefs: {
       status: 200,

--- a/test/main_test.js
+++ b/test/main_test.js
@@ -19,7 +19,7 @@ const endpointUrls = JSON.stringify({
 });
 
 // Tests for elements visible to all users
-describe('when plugin is started', function() {
+describe('when external module is started', function() {
 
   let originalDatepicker;
 
@@ -37,7 +37,7 @@ describe('when plugin is started', function() {
     $('.vizr-container').remove();
   });
 
-  describe('unconfigured plugin', function() {
+  describe('unconfigured external module', function() {
     let metadataRequest, configRequest;
 
     beforeEach(function() {
@@ -48,7 +48,7 @@ describe('when plugin is started', function() {
     });
 
     it('emits error', function() {
-      expect($('.error')).toContainText('The plugin is not configured');
+      expect($('.error')).toContainText('The external module is not configured');
     });
 
   });

--- a/test/main_test.js
+++ b/test/main_test.js
@@ -9,6 +9,13 @@ import { run } from '../js/main';
 
 // The DOM expected by the run method of main.js
 const chart = '<div class="vizr-container"><div id="vizr-instructions"/><div class="vizr-charts"/></div>';
+const endpointUrls = {
+  'lib/chart_defs.php': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fchart_defs&pid=0',
+  'lib/data': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fdata&pid=0',
+  'lib/metadata': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fmetadata&pid=0',
+  'lib/permissions': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fpermissions&pid=0',
+  'lib/persist': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fpersist&pid=0'
+};
 
 // Tests for elements visible to all users
 describe('when plugin is started', function() {
@@ -20,7 +27,7 @@ describe('when plugin is started', function() {
     originalDatepicker = $.fn.datepicker;
     $.fn.datepicker = () => {};
     $(chart).appendTo('body');
-    run(0, false);
+    run(0, false, endpointUrls);
   });
 
   afterEach(function() {
@@ -227,7 +234,7 @@ describe('when user can edit', function() {
     originalDatepicker = $.fn.datepicker;
     $.fn.datepicker = () => {};
     $(chart).appendTo('body');
-    run(0, true);
+    run(0, true, endpointUrls);
   });
 
   afterEach(function() {
@@ -292,7 +299,7 @@ describe('when user can edit', function() {
       it('saves config when legend is toggled', () => {
         $('[data-description="toggle-legend"]').click();
         const persistenceRequest = jasmine.Ajax.requests.mostRecent();
-        expect(persistenceRequest.url).toEqual('lib/persist.php?pid=0');
+        expect(persistenceRequest.url).toEqual('http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fpersist&pid=0');
         persistenceRequest.respondWith(exampleResponses.persistence.successful);
       });
 
@@ -311,7 +318,7 @@ describe('when user cannot edit', function() {
     originalDatepicker = $.fn.datepicker;
     $.fn.datepicker = () => {};
     $(chart).appendTo('body');
-    run(0, false);
+    run(0, false, endpointUrls);
   });
 
   afterEach(function() {

--- a/test/main_test.js
+++ b/test/main_test.js
@@ -9,13 +9,14 @@ import { run } from '../js/main';
 
 // The DOM expected by the run method of main.js
 const chart = '<div class="vizr-container"><div id="vizr-instructions"/><div class="vizr-charts"/></div>';
-const endpointUrls = {
-  'lib/chart_defs.php': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fchart_defs&pid=0',
-  'lib/data': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fdata&pid=0',
-  'lib/metadata': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fmetadata&pid=0',
-  'lib/permissions': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fpermissions&pid=0',
-  'lib/persist': 'http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fpersist&pid=0'
-};
+const endpointBase = 'http://localhost/redcap/api/?type=module&prefix=vizr&page=';
+const endpointUrls = JSON.stringify({
+  'lib/chart_defs.php': `${endpointBase}lib%2Fchart_defs&pid=0`,
+  'lib/data.php': `${endpointBase}lib%2Fdata&pid=0`,
+  'lib/metadata.php': `${endpointBase}lib%2Fmetadata&pid=0`,
+  'lib/permissions.php': `${endpointBase}lib%2Fpermissions&pid=0`,
+  'lib/persist.php': `${endpointBase}lib%2Fpersist&pid=0`
+});
 
 // Tests for elements visible to all users
 describe('when plugin is started', function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,8 @@ module.exports = {
       'VizrConfigurationProject*',
       'index.php',
       watching ? '*config.php' : 'example_config.php',
+      'Vizr.php',
+      'config.json',
       'lib/**/*.php'
     ]),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
This completes the full migration to external modules sans persistence. It still requires the config project, but there's a TODO in the IMPLEMENTATION.md file to update that next.

I did my best to update the documentation so please point out anything that doesn't make sense. Or if I missed anything specific to plugins, exception for the config project part. I'm going to work on that bit next.

`Vizr.php` is the entry point for external modules and is required.

`config.json` defines some metadata, permissions, and the link display. Currently looks like this: https://imgur.com/Pd6Tlqz

I've also updated the vizr `docker-compose.yml`. I'll send another PR for that.

The main work that needed to be done was in `lib/main.tmpl` and `js/main.js`. All of the requires/includes are absolute and the endpoints needed to be retrieved with the external module `getUrl()` function. The `Vizr.run()` method now takes a third argument with those URLs defined in a JSON string.

There's a lot of changes but they're pretty simple. Let me know if you have any questions. It may be best to just read the markdown files in full.