### PR TITLE
REDDEV-540 Plugin: Require Selecting Date Interval

### DIFF
--- a/js/chart-form-template.js
+++ b/js/chart-form-template.js
@@ -119,6 +119,9 @@ export const formTemplate = `
         <div class="form-group">
           <label for="date_interval" class="control-label">Date Interval</label>
           <select class="form-control" name="date_interval" required="required" data-field='dateInterval'>
+            <option value="">
+              Select an interval
+            </option>
             {{#dateIntervals}}
             {{> option}}
             {{/dateIntervals}}

--- a/test/chart-form_test.js
+++ b/test/chart-form_test.js
@@ -42,11 +42,11 @@ describe('chartForm', () => {
 
   it('creates the expected date interval options', () => {
     const dateIntervalOptions = chart.find('select[name=date_interval] > option');
-    expect(dateIntervalOptions.length).toEqual(4); // 4 options
-    expect(dateIntervalOptions.eq(0).text().trim()).toEqual('Days');
-    expect(dateIntervalOptions.eq(1).text().trim()).toEqual('Weeks');
-    expect(dateIntervalOptions.eq(2).text().trim()).toEqual('Months');
-    expect(dateIntervalOptions.eq(3).text().trim()).toEqual('Years');
+    expect(dateIntervalOptions.length).toEqual(5); // 4 options plus prompt
+    expect(dateIntervalOptions.eq(1).text().trim()).toEqual('Days');
+    expect(dateIntervalOptions.eq(2).text().trim()).toEqual('Weeks');
+    expect(dateIntervalOptions.eq(3).text().trim()).toEqual('Months');
+    expect(dateIntervalOptions.eq(4).text().trim()).toEqual('Years');
   });
 
   it('creates the expected grouping field options', () => {


### PR DESCRIPTION
Add a prompt option to the date interval <select> to be more consistent with other options and to ensure validation fails at the front end so invalid configuration is not submitted.