### PR TITLE
ESLint for Tests

### DIFF
--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "jasmine": true
+  }
+}

--- a/test/bucket_test.js
+++ b/test/bucket_test.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 import {
   dateBuckets, groupedByInterval, summarizeGroups, trendPoints
 } from '../js/bucket';

--- a/test/chart-config_test.js
+++ b/test/chart-config_test.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 import {
   makeChart, makeStackedChart, labelOpts
 } from '../js/chart-config';

--- a/test/chart-form_test.js
+++ b/test/chart-form_test.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 import $ from 'jquery';
 
 import { newChartDefinition } from '../js/util';

--- a/test/data-dictionary_test.js
+++ b/test/data-dictionary_test.js
@@ -1,5 +1,3 @@
-/* eslint-env jasmine */
-
 import {
   findField,
   isDateField,

--- a/test/html_test.js
+++ b/test/html_test.js
@@ -1,6 +1,4 @@
-/* eslint-env jasmine */
-import {ul, li} from '../js/html';
-
+import { ul, li } from '../js/html';
 
 describe('html generation', () => {
 

--- a/test/main_test.js
+++ b/test/main_test.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 import 'jasmine-ajax';
 import 'jasmine-jquery';
 

--- a/test/summary-table_test.js
+++ b/test/summary-table_test.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 import {
   statistics,
   render,

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -1,4 +1,3 @@
-/* eslint-env jasmine */
 import {
   isoToUserDate,
   title,


### PR DESCRIPTION
Configure ESLint to know that the tests use Jasmine, removing the need for the `eslint-env` comment.