### PR TITLE
REDDEV-530 ; chart reload bug

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -119,6 +119,7 @@ function reloadLink(metadata, config, chartDef) {
   reloadLink.on('click', () => {
     $(`#chart-${chartDef.id}`).find(".vizr-chart-summary").empty();
     $(`#chart-${chartDef.id}`).find('.error').empty();
+    $(`#chart-${chartDef.id}`).find('.vizr-event-select').empty();
     getChartData(config, null, chartDef, metadata.recordIdField)
   });
 


### PR DESCRIPTION
Clears existing event filter dropdown when chart is reloaded.