### PR TITLE
Fix Broken Image

### DIFF
--- a/js/components/ExampleChart.vue
+++ b/js/components/ExampleChart.vue
@@ -1,6 +1,6 @@
 <template>
   <figure class="pull-right vizr-example">
-    <img src="lib/vizr_example.png" :alt="messages.imgTitle" class="img-thumbnail" :title="messages.imgTitle">
+    <img :src="imgSrc" :alt="messages.imgTitle" class="img-thumbnail" :title="messages.imgTitle">
     <figcaption>
       <strong>{{ messages.captionIntro }}</strong> {{ messages.captionTitle }}
     </figcaption>
@@ -8,8 +8,11 @@
 </template>
 
 <script>
+import exampleImage from '../../lib/vizr_example.png';
+
 export default {
   name: 'ExampleChart',
+  inject: ['assetUrls'],
 
   data() {
     return {
@@ -19,6 +22,13 @@ export default {
         imgTitle: 'Example Vizr Chart - Screened In Results'
       }
     };
+  },
+
+  computed: {
+    imgSrc() {
+      const { assetUrls = {} } = this;
+      return assetUrls[exampleImage] || exampleImage;
+    }
   }
 }
 </script>

--- a/js/vue-main.js
+++ b/js/vue-main.js
@@ -14,19 +14,22 @@ import Vizr from './components/Vizr';
  *   external module URL like `http://localhost/redcap/api/?type=module&prefix=vizr&page=lib%2Fdata&pid=14`
  */
 export function run(pid, canEdit, jsonAssetUrls) {
-  const parsedAssetUrls = JSON.parse(jsonAssetUrls);
-
   /**
    * Instantiate the Vue component tree.
    */
   new Vue({
     el: '.vizr-container',
+    components: { Vizr },
+    template: '<Vizr :pid="pid" :can-edit="canEdit"/>',
     data: {
       pid,
       canEdit,
-      jsonAssetUrls: parsedAssetUrls
+      assetUrls: JSON.parse(jsonAssetUrls)
     },
-    components: { Vizr },
-    template: '<Vizr :pid="pid" :can-edit="canEdit"/>'
+    provide() {
+      return {
+        assetUrls: this.assetUrls
+      };
+    }
   });
 }

--- a/test/components/ExampleChart_test.js
+++ b/test/components/ExampleChart_test.js
@@ -1,11 +1,24 @@
 import { shallowMount } from '@vue/test-utils';
+
 import ExampleChart from '@/components/ExampleChart';
+import chartImage from '../../lib/vizr_example.png';
 
 describe('ExampleChart.vue', () => {
   it('renders a figure with an image and caption', () => {
-    const wrapper = shallowMount(ExampleChart);
+    const mockUrl = `https://example.com${chartImage}`;
+    const wrapper = shallowMount(ExampleChart, {
+      provide: {
+        assetUrls: {
+          [chartImage]: mockUrl
+        }
+      }
+    });
+
     expect(wrapper.find('figure.vizr-example').exists()).toBe(true);
-    expect(wrapper.find('figure img').exists()).toBe(true);
     expect(wrapper.find('figure figcaption').exists()).toBe(true);
+
+    // it gets the image URL via injection
+    expect(wrapper.find('figure img').exists()).toBe(true);
+    expect(wrapper.find('img').attributes().src).toEqual(mockUrl);
   });
 });

--- a/test/components/Vizr_test.js
+++ b/test/components/Vizr_test.js
@@ -11,11 +11,16 @@ import { chartId, exampleChartDef, exampleLongitudinalChartDef } from '../exampl
 import Vizr from '@/components/Vizr';
 
 describe('Vizr.vue', () => {
+  const mockProvide = {
+    assetUrls: {}
+  };
+
   it('renders', () => {
     const wrapper = shallowMount(Vizr, {
       propsData: {
         canEdit: false
-      }
+      },
+      provide: mockProvide
     });
 
     const heading = wrapper.find('h1');
@@ -41,6 +46,7 @@ describe('Vizr.vue', () => {
       it('emits error', function() {
         const config = { error: 'The plugin is not configured' };
         const wrapper = shallowMount(Vizr, {
+          provide: mockProvide,
           data() {
             return {
               metadata: exampleMetadata,
@@ -244,6 +250,7 @@ describe('Vizr.vue', () => {
         // configRequest.respondWith(exampleResponses.config.noChartDefs);
 
         wrapper = mount(Vizr, {
+          provide: mockProvide,
           propsData: {
             canEdit: true
           }


### PR DESCRIPTION
Fix broken image in `ExampleChart` component by injecting asset URLs. Resolves #15.