### PR TITLE
REDDEV-539 project settings

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,6 +37,13 @@
   "permissions": [
     "select_data"
   ],
+  "project-settings": [
+    {
+      "key": "chart-definitions",
+      "type": "json-array",
+      "value": "[]"
+    }
+  ],
   "links": {
     "project": [
       {


### PR DESCRIPTION
By adding a default `chart-definitions` entry to `project-settings` in `config.json` it allows for the "Module configuration permissions in projects" option when configuring an external module. This matches what was shown in the screenshot attached to the issue. I'm not sure if we need to touch `lib/permissions.php` but figured this would be a start.