### PR TITLE
REDDEV-539 config update

### DIFF
--- a/config.json
+++ b/config.json
@@ -39,9 +39,9 @@
   ],
   "project-settings": [
     {
-      "key": "chart-definitions",
-      "type": "json-array",
-      "value": "[]"
+      "key": "vizr-descriptive",
+      "name": "To configure a chart, click the Vizr link under <strong>External Modules</strong> on the left navigation bar. On that page there's a link titled \"Vizr charts are configured\" which contains documentation for building charts.",
+      "type": "descriptive"
     }
   ],
   "links": {


### PR DESCRIPTION
The previous definition which produced the configuration option wasn't correct.

This,

```
{
  "key": "chart-definitions",
  "type": "json-array",
  "value": "[]"
}
```

should have been,

```
{
  "name": "Chart Definitions",
  "key": "chart-definitions",
  "type": "json-array"
}
```

however that would allow someone to enter a chart definition manually, and possibly wipe out the entrie set of chart definitions. I'm not sure we want to do that.

I think that drop-down shown in the JIRA issue is what controls permissions for editing the project settings. If that's the case, we may need to leave `lib/permissions.php` as-is. If we want to configure a chart using the project settings, then we may need to define the chart properties in `config.json`. I'm looking into this now but won't have a chance to talk to Liz until tomorrow.

For now I'm just adding some descriptive text which points them to the Vizr documentation. This is what some modules do.