### PR TITLE
Chart Summary Component

### DIFF
--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -25,8 +25,13 @@
 
     <div class="vizr-chart-data-container">
       <div class="row">
-        <!-- TODO #16 ChartSummary component -->
-        <div class="vizr-chart-summary col-md-4"></div>
+        <ChartSummary
+          class="vizr-chart-summary col-md-4"
+          :total-count="totalCount"
+          :total-target="totalTarget"
+          :group="chartDef.group"
+          :group-data="summary"/>
+
         <div class="vizr-chart col-md-8">
           <!-- TODO #25 click handler for legend toggle -->
           <a href="#"
@@ -46,6 +51,8 @@
 <script>
 import { groupedByInterval, summarizeGroups, trendPoints } from '@/bucket';
 import { makeStackedChart } from '@/chart-config';
+
+import ChartSummary from '@/components/ChartSummary';
 
 const messages = {
   actions : {
@@ -75,6 +82,10 @@ export default {
     canEdit: Boolean,
     chartDef: Object,
     metadata: Object
+  },
+
+  components: {
+    ChartSummary
   },
 
   data() {

--- a/js/components/ChartSummary.vue
+++ b/js/components/ChartSummary.vue
@@ -148,7 +148,7 @@ export default {
         // Group target must exist and be non-zero to display
         const targetDisplay = this.targetString(target); // optional form field
         const countStr = (count !== undefined && count !== null) ? count.toString() : "";
-        // return [groupLabel, countStr, targetDisplay, this.pct(count, target), this.pct(count, total)];
+
         return {
           label: groupLabel,
           count: countStr,

--- a/js/components/ChartSummary.vue
+++ b/js/components/ChartSummary.vue
@@ -1,0 +1,188 @@
+<template>
+  <div>
+    <div>
+      <table ref="totalsTable" class="table table-striped table-bordered">
+        <caption>
+          {{ messages.totalsCaption }}
+          <button class="copy-link pull-right btn btn-link btn-sm" @click="copyTable($refs.totalsTable)">
+            <span
+              class="glyphicon glyphicon-copy"
+              aria-hidden="true"
+              :title="messages.copyTable">
+            </span>
+          </button>
+        </caption>
+        <thead>
+          <tr>
+            <th>{{ messages.resultsCount }}</th>
+            <th>{{ messages.target }}</th>
+            <th>{{ messages.percent }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ totalCount }}</td>
+            <td>{{ totalTarget }}</td>
+            <td>{{ totalPct }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <table ref="groupedTable" class="table table-striped table-bordered" v-if="group">
+      <caption>
+        {{ messages.groupedCaption }}
+        <button class="copy-link pull-right btn btn-link btn-sm" @click="copyTable($refs.groupedTable)">
+          <span
+            class="glyphicon glyphicon-copy"
+            aria-hidden="true"
+            :title="messages.copyTable">
+          </span>
+        </button>
+      </caption>
+      <thead>
+        <tr>
+          <th>{{ groupTitle }}</th>
+          <th>{{ messages.resultsCount }}</th>
+          <th>{{ messages.target }}</th>
+          <th>{{ messages.percent }}</th>
+          <th>{{ messages.percentOfTotal }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="group in groupStats" :key="group.label">
+          <td>{{ group.label }}</td>
+          <td>{{ group.count }}</td>
+          <td>{{ group.target }}</td>
+          <td>{{ group.percentOfTarget }}</td>
+          <td>{{ group.percentOfTotal }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import { copyContents, notAnsweredLabel, title } from '@/util';
+
+const messages = {
+  copyTable: 'Copy table to clipboard',
+  groupedCaption: 'Grouped Results',
+  percent: 'Percent',
+  percentOfTotal: 'Percent of Total',
+  resultsCount: 'Results Count',
+  target: 'Target',
+  totalsCaption: 'Total Number of Results',
+};
+
+/**
+ * Chart summary component. Displays counts and percentages in a tabular format.
+ */
+export default {
+  name: 'ChartSummary',
+
+  props: {
+    group: String,
+    groupData: Object,
+    totalCount: Number,
+    totalTarget: Number
+  },
+
+  data() {
+    return {
+      messages
+    };
+  },
+
+  methods: {
+    /**
+     * Calculate the percent and return a string for display.
+     * @param {Number} num - numerator
+     * @param {Number} total - denominator
+     * @return {String} percent as a string with a single decimal; ex. '32.3%'
+     */
+    pct(num, total) {
+      if (isNaN(parseFloat(num)) || isNaN(parseFloat(total)) || total === 0) {
+        return "";
+      }
+
+      const value = (num / total) * 100;
+      return `${value.toFixed(2)}%`;
+    },
+
+    /**
+     * Returns a string representation of a target for display.
+     * @param {Number} target - the target to convert
+     * @return {String} target as a string; calculated targets with fractional values are
+     *   rounded to two decimals
+     */
+    targetString(target) {
+      if (!target) {
+        return "";
+      }
+
+      return Number.isInteger(target) ? target.toString() : target.toFixed(2);
+    },
+
+    /**
+     * Generates a breakdown of statistics by group that can be rendered in a table.
+     * @param {Object} groupData - { groupName: {count: _ , target: _ }, ...}
+     * @return {Object[]} - ex.
+     * [
+     *  {label: group1Name, count: _, target: _, percentOfTarget: _, percentOfTotal: _},
+     *  ...
+     * ]
+     */
+    statistics(groupData) {
+      const groups = Object.keys(groupData);
+      groups.sort();
+
+      const total = groups.reduce((c, k) => {
+        return c + groupData[k].count;
+      }, 0);
+
+      return groups.map(group => {
+        const groupLabel = group ? group : notAnsweredLabel;
+        const data = groupData[group];
+        const { count, target } = data;
+        // Group target must exist and be non-zero to display
+        const targetDisplay = this.targetString(target); // optional form field
+        const countStr = (count !== undefined && count !== null) ? count.toString() : "";
+        // return [groupLabel, countStr, targetDisplay, this.pct(count, target), this.pct(count, total)];
+        return {
+          label: groupLabel,
+          count: countStr,
+          target: targetDisplay,
+          percentOfTarget: this.pct(count, target),
+          percentOfTotal: this.pct(count, total)
+        };
+      });
+    },
+
+    /**
+     * Copies the contents of the target table to the clipboard.
+     * @param {Element} target - a DOM element
+     */
+    copyTable(target) {
+      copyContents(target);
+    }
+  },
+
+  computed: {
+    totalPct() {
+      const { totalCount, totalTarget } = this;
+      return this.pct(totalCount, totalTarget);
+    },
+
+    groupTitle() {
+      const { group } = this;
+      return group ? title(group) : '';
+    },
+
+    groupStats() {
+      const { groupData } = this;
+      return groupData ? this.statistics(groupData) : [];
+    }
+  }
+}
+</script>

--- a/js/util.js
+++ b/js/util.js
@@ -64,7 +64,7 @@ export function copyLink(targetNode) {
  * http://stackoverflow.com/questions/2044616/select-a-complete-table-with-javascript-to-be-copied-to-clipboard
  * http://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
  */
-function copyContents(el) {
+export function copyContents(el) {
   var body = document.body, range, sel;
   if (document.createRange && window.getSelection) {
     range = document.createRange();

--- a/test/components/ChartSummary_test.js
+++ b/test/components/ChartSummary_test.js
@@ -1,0 +1,218 @@
+import { shallowMount } from '@vue/test-utils';
+
+import ChartSummary from '@/components/ChartSummary';
+import { notAnsweredLabel } from '@/util';
+
+const totalCount = 60;
+const totalTarget= 90;
+
+const groupData = {
+  Bend: { count: 10 , target: 20 },
+  Eugene: { count: 20 , target: 30 },
+  Portland: { count: 30 , target: 40 }
+};
+
+const expected = {
+  pct: {
+    bend: '50.00%',
+    eugene: '66.67%',
+    portland: '75.00%'
+  },
+  pctTotal: {
+    bend: '16.67%',
+    eugene: '33.33%',
+    portland: '50.00%'
+  }
+};
+
+const groupField = 'study_clinic';
+
+describe('ChartSummary.vue', () => {
+  describe('rendering', () => {
+    let wrapper, tables;
+
+    beforeEach(() => {
+      wrapper = shallowMount(ChartSummary, {
+        propsData: {
+          totalCount,
+          totalTarget,
+          groupData,
+          group: groupField
+        }
+      });
+
+      tables = wrapper.findAll('table');
+    });
+
+    it('displays two tables', () => {
+      expect(wrapper.findAll('table').length).toEqual(2);
+    });
+
+    it('displays a totals table with a single row', () => {
+      const totals = tables.at(0);
+      expect(totals.findAll('tbody tr').length).toEqual(1);
+    });
+
+    it('displays the total results', () => {
+      const totals = tables.at(0);
+      expect(totals.findAll('td').at(0).text()).toEqual(totalCount.toString());
+    });
+
+    it('displays the total target', () => {
+      const totals = tables.at(0);
+      expect(totals.findAll('td').at(1).text()).toEqual(totalTarget.toString());
+    });
+
+    it('displays the total percent of the target reached', () => {
+      const totals = tables.at(0);
+      expect(totals.findAll('td').at(2).text()).toEqual('66.67%');
+    });
+
+    it('displays a second table with a summary row for each group', () => {
+      const groups = tables.at(1);
+      expect(groups.findAll('tbody tr').length).toEqual(Object.keys(groupData).length);
+    });
+
+    it('has a header for the grouping field', () => {
+      const groups = tables.at(1);
+      expect(groups.findAll('th').at(0).text()).toEqual('Study Clinic');
+    });
+
+    it('has a copy link for each table', () => {
+      const buttons = wrapper.findAll('button.copy-link');
+      expect(buttons.length).toEqual(2);
+    });
+
+    it('copies the table data when the link is clicked', () => {
+      spyOn(wrapper.vm, 'copyTable');
+
+      const table = wrapper.findAll('table').at(1);
+      const button = table.find('button');
+      button.trigger('click');
+
+      expect(wrapper.vm.copyTable).toHaveBeenCalledWith(wrapper.vm.$refs.groupedTable);
+    });
+  });
+
+  describe('statistics', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = shallowMount(ChartSummary, {
+        propsData: {
+          totalCount,
+          totalTarget
+        }
+      });
+    });
+
+    it('should output the correct values', () => {
+      const rows = wrapper.vm.statistics(groupData);
+      expect(rows[0]).toEqual({
+        label: 'Bend',
+        count: '10',
+        target: '20',
+        percentOfTarget: expected.pct.bend,
+        percentOfTotal: expected.pctTotal.bend
+      });
+      expect(rows[1]).toEqual({
+        label: 'Eugene',
+        count: '20',
+        target: '30',
+        percentOfTarget: expected.pct.eugene,
+        percentOfTotal: expected.pctTotal.eugene
+      });
+      expect(rows[2]).toEqual({
+        label: 'Portland',
+        count: '30',
+        target: '40',
+        percentOfTarget: expected.pct.portland,
+        percentOfTotal: expected.pctTotal.portland
+      });
+    });
+
+    it('should work with no data', () => {
+      const rows = wrapper.vm.statistics({});
+      expect(rows.length).toBe(0);
+    });
+
+    it('should display empty target data if values were not provided', () => {
+      const noTargetData = {
+        Bend: {count: 10 , target: null },
+        Eugene: {count: 20 , target: null },
+        Portland: {count: 30 , target: null }
+      };
+
+      const rows = wrapper.vm.statistics(noTargetData);
+      expect(rows[0]).toEqual({
+        label: 'Bend',
+        count: '10',
+        target: '',
+        percentOfTarget: '',
+        percentOfTotal: expected.pctTotal.bend
+      });
+      expect(rows[1]).toEqual({
+        label: 'Eugene',
+        count: '20',
+        target: '',
+        percentOfTarget: '',
+        percentOfTotal: expected.pctTotal.eugene
+      });
+      expect(rows[2]).toEqual({
+        label: 'Portland',
+        count: '30',
+        target: '',
+        percentOfTarget: '',
+        percentOfTotal: expected.pctTotal.portland
+      });
+    });
+
+    it('should provide a Not Answered row if group field was optional', () => {
+      const optionalGroupData = {
+        '': {count: 60, target: 0},
+        Bend: {count: 10 , target: 20 },
+        Eugene: {count: 20 , target: 30 },
+        Portland: {count: 30 , target: 40 }
+      };
+
+      const rows = wrapper.vm.statistics(optionalGroupData);
+      expect(rows[0]).toEqual({
+        label: notAnsweredLabel,
+        count: '60',
+        target: '',
+        percentOfTarget: '',
+        percentOfTotal: '50.00%'
+      });
+      expect(rows[1]).toEqual({
+        label: 'Bend',
+        count: '10',
+        target: '20',
+        percentOfTarget: '50.00%',
+        percentOfTotal: '8.33%'
+      });
+      expect(rows[2]).toEqual({
+        label: 'Eugene',
+        count: '20',
+        target: '30',
+        percentOfTarget: '66.67%',
+        percentOfTotal: '16.67%'
+      });
+      expect(rows[3]).toEqual({
+        label: 'Portland',
+        count: '30',
+        target: '40',
+        percentOfTarget: '75.00%',
+        percentOfTotal: '25.00%'
+      });
+    });
+
+    it('should round calculated targets to 2 decimals', () => {
+      const calculatedTargetData = {
+        Bend: {count: 10, target: 100 / 3}
+      };
+
+      const [ row ] = wrapper.vm.statistics(calculatedTargetData);
+      expect(row.target).toEqual('33.33');
+    });
+  })
+});

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -1,6 +1,8 @@
 import { shallowMount } from '@vue/test-utils';
 
 import Chart from '@/components/Chart';
+import ChartSummary from '@/components/ChartSummary';
+
 import { exampleChartDef, exampleLongitudinalChartDef } from '../example-chart-def';
 import { exampleMetadata, exampleLongitudinalMetadata } from '../example-metadata';
 import { exampleResponses } from '../example-ajax-responses';
@@ -55,14 +57,8 @@ describe('Chart.vue', () => {
       });
 
       it('shows a chart summary', () => {
-        expect(wrapper.contains('.vizr-chart-summary')).toBe(true);
+        expect(wrapper.contains(ChartSummary)).toBe(true);
       });
-
-      // TODO #16 chart summary component
-      // it('summary contains 2 tables with copy links', () => {
-      //   expect($('.vizr-chart-summary table')).toHaveLength(2);
-      //   expect($('.vizr-chart-summary .copy-link')).toHaveLength(2);
-      // });
 
       it('shows a chart', () => {
         expect(wrapper.contains('.vizr-chart canvas')).toBe(true);
@@ -147,14 +143,8 @@ describe('Chart.vue', () => {
       });
 
       it('shows a chart summary', () => {
-        expect(wrapper.contains('.vizr-chart-summary')).toBe(true);
+        expect(wrapper.contains(ChartSummary)).toBe(true);
       });
-
-      // TODO #16 chart summary component
-      // it('summary contains 2 tables with copy links', () => {
-      //   expect($('.vizr-chart-summary table')).toHaveLength(2);
-      //   expect($('.vizr-chart-summary .copy-link')).toHaveLength(2);
-      // });
 
       it('shows a chart', () => {
         expect(wrapper.contains('.vizr-chart canvas')).toBe(true);


### PR DESCRIPTION
Implement a component that displays the summary tables. Fixes #17.

## Screenshot

Now pretty much there visually:

![summary-tables](https://user-images.githubusercontent.com/2746306/41950547-5ee96e74-797b-11e8-919c-a3571b55b7fa.png)
