### PR TITLE
Provide Element to Chart Construction

### DIFF
--- a/js/chart-config.js
+++ b/js/chart-config.js
@@ -1,22 +1,21 @@
 import Chart from 'chart.js';
-import $ from "jquery";
 import { notAnsweredLabel } from './util.js';
 
 // Color scheme for qualitative data, where color is used primarily to distinguish
 // between categories, rather than indicate relative values. (see colorbrewer2)
 const colors = [
-'rgba(166,206,227, 0.75)',
-'rgba(31,120,180, 0.75)',
-'rgba(178,223,138, 0.75)',
-'rgba(51,160,44, 0.75)',
-'rgba(251,154,153, 0.75)',
-'rgba(227,26,28, 0.75)',
-'rgba(253,191,111, 0.75)',
-'rgba(255,127,0, 0.75)',
-'rgba(202,178,214, 0.75)',
-'rgba(106,61,154, 0.75)',
-'rgba(255,255,153, 0.75)',
-'rgba(177,89,40, 0.75)'
+  'rgba(166,206,227, 0.75)',
+  'rgba(31,120,180, 0.75)',
+  'rgba(178,223,138, 0.75)',
+  'rgba(51,160,44, 0.75)',
+  'rgba(251,154,153, 0.75)',
+  'rgba(227,26,28, 0.75)',
+  'rgba(253,191,111, 0.75)',
+  'rgba(255,127,0, 0.75)',
+  'rgba(202,178,214, 0.75)',
+  'rgba(106,61,154, 0.75)',
+  'rgba(255,255,153, 0.75)',
+  'rgba(177,89,40, 0.75)'
 ];
 
 /**
@@ -46,12 +45,11 @@ export function labelOpts(labelCount) {
    }).use;
 }
 
-function newChart(chartdata, chartDef) {
-  let {id, title, hide_legend} = chartDef;
-  var ctx = $("#" + id);
+function newChart(canvas, chartdata, chartDef) {
+  let { title, hide_legend } = chartDef;
   let lblOpts = chartdata.datasets ? labelOpts(chartdata.datasets.length) : {}
 
-  let chart = new Chart(ctx, {
+  let chart = new Chart(canvas, {
     type: 'bar',
     data: chartdata,
     options: {
@@ -99,6 +97,7 @@ function newChart(chartdata, chartDef) {
 /**
  * Creates a stacked bar chart (with optional trend line) and adds it to the canvas.
  *
+ * @param {Element} canvas - HTML canvas element, captured using jQuery or DOM API.
  * @param {} data - grouped data; ex. {group1: {"2016-10-02": 2, "2016-10-09": 3, ...}, group2: ...}
  * @param {Object} chartDef - chart definition; contains canvas element id and
  *   chart title.
@@ -106,7 +105,7 @@ function newChart(chartdata, chartDef) {
  *   draw a trendline.
  * @return {Chart}
  */
-export function makeStackedChart(groupedData, chartDef, trendPoints) {
+export function makeStackedChart(canvas, groupedData, chartDef, trendPoints) {
   let groups = Object.keys(groupedData);
 
   let labels = null;
@@ -147,17 +146,18 @@ export function makeStackedChart(groupedData, chartDef, trendPoints) {
     datasets : datasets
   };
 
-  return newChart(chartdata, chartDef);
+  return newChart(canvas, chartdata, chartDef);
 }
 
 /**
  * Constructs a chart.js chart
  *
+ * @param {Element} canvas - HTML canvas element, captured using jQuery or DOM API.
  * @param {} data - chart data; {"2016-10-02": 2, "2016-10-09": 3, ...}
  * @param {Object} chartDef - chart definition; contains canvas element id and
  *   chart title.
  */
-export function makeChart(data, chartDef) {
+export function makeChart(canvas, data, chartDef) {
 
   let x = Object.keys(data);
   let y = x.map(k => { return data[k]; });
@@ -175,5 +175,5 @@ export function makeChart(data, chartDef) {
     ]
   };
 
-  return newChart(chartdata, chartDef);
+  return newChart(canvas, chartdata, chartDef);
 }

--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -40,7 +40,7 @@
              data-description="toggle-legend"
              @click.prevent="toggleLegend"
           >{{ messages.actions.toggleLegend }}</a>
-          <canvas :id="id"></canvas>
+          <canvas ref="canvas" :id="id"></canvas>
         </div>
       </div>
       <a href="#"
@@ -164,10 +164,11 @@ export default {
 
     _makeChart() {
       const { chartDef, grouped, trendPoints } = this;
+      const { canvas } = this.$refs;
       if (this.chart) {
         this.chart.destroy();
       }
-      this.chart = makeStackedChart(grouped, chartDef, trendPoints);
+      this.chart = makeStackedChart(canvas, grouped, chartDef, trendPoints);
     },
 
     _clearChart() {

--- a/js/main.js
+++ b/js/main.js
@@ -234,6 +234,7 @@ function legendToggleLink(config, chartDef) {
  */
 function addSummary(config, chartDef, data) {
   const container = $(`#chart-${chartDef.id}`);
+  const canvas = container.find('canvas');
   const chartEnd = chartDef.chartEnd ? chartDef.chartEnd : new Date(); // today
   const dateInterval = chartDef.dateInterval || 'week'; // Set a default for backward compatibility
   const grouped = groupedByInterval(data, chartDef.field, chartDef.start, chartEnd,
@@ -255,7 +256,7 @@ function addSummary(config, chartDef, data) {
 
   $(container).find('.vizr-chart-summary').append(...summaryTables);
   const pts = trendPoints(chartDef.start, chartDef.end, dateInterval, totalTarget);
-  let chart = makeStackedChart(grouped, chartDef, pts);
+  let chart = makeStackedChart(canvas, grouped, chartDef, pts);
 
   // Add click handler to the Toggle Legend link which toggles the chart legend
   $(container).find('.vizr-chart-legend-toggle').on('click', () => {

--- a/test/chart-config_test.js
+++ b/test/chart-config_test.js
@@ -30,8 +30,9 @@ const data = {
 describe('chart creation', () => {
   const chartId = 'screenedChart';
   $('body').append($(`<div class="vizr-chart-container"><canvas id="${chartId}"></canvas></div`));
+  const canvas = $('canvas');
 
-  const chart = makeChart(data, chartId, 'Screened Participants');
+  const chart = makeChart(canvas, data, chartId, 'Screened Participants');
 
   it('should create a chart object', () => {
     expect(chart).toBeDefined();
@@ -60,15 +61,16 @@ const trendpts = [
 describe('stacked chart creation', () => {
   const chartId = 'screenedChart';
   $('body').append($(`<div class="vizr-chart-container"><canvas id="${chartId}"></canvas></div`));
+  const canvas = $('canvas');
 
-  const chart = makeStackedChart(groupedData, {id: chartId, title: 'Screened Participants by Group'}, trendpts);
+  const chart = makeStackedChart(canvas, groupedData, {id: chartId, title: 'Screened Participants by Group'}, trendpts);
 
   it('should create a stacked chart object with trend points', () => {
     expect(chart
     ).toBeDefined();
   });
 
-  const chartNoTrendpts = makeStackedChart(groupedData, {id: chartId, title: 'Screened Participants by Group'});
+  const chartNoTrendpts = makeStackedChart(canvas, groupedData, {id: chartId, title: 'Screened Participants by Group'});
 
   it('should create a stacked chart object without trend points', () => {
     expect(chartNoTrendpts).toBeDefined();


### PR DESCRIPTION
Add an argument to the the functions that construct charts to pass the canvas element to use, rather than searching the DOM for an element with a known ID. Fixes #30.

This is more efficient and enables the use of a ref in the Vue component, which fixes some warnings in the chart component tests.