### PR TITLE
Persistence

### DIFF
--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -202,13 +202,13 @@ export default {
      * Click event handler for the legend toggle link.
      */
     toggleLegend() {
-      const { canEdit, chart, chartDef, id } = this;
+      const { canEdit, chart, chartDef } = this;
       chart.config.options.legend.display = !chart.config.options.legend.display;
       chart.update();
 
       if (canEdit) {
         chartDef.hide_legend = !chartDef.hide_legend;
-        this.$emit('toggle-legend', id);
+        this.$emit('toggle-legend', chartDef);
       }
     },
 

--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -185,9 +185,9 @@ export default {
      * Click event handler for the delete link.
      */
     deleteChart() {
-      const { chartDef, id, messages } = this;
+      const { chartDef, messages } = this;
       if (confirm(`${messages.actions.confirmDelete}: ${chartDef.title}?`)) {
-        this.$emit('delete-chart', id);
+        this.$emit('delete-chart', chartDef);
       }
     },
 

--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -299,6 +299,15 @@ export default {
       const { chartDef, dateInterval, totalTarget } = this;
       return trendPoints(chartDef.start, chartDef.end, dateInterval, totalTarget);
     }
+  },
+
+  watch: {
+    /**
+     * Watches the `chartDef` prop for changes, indicating that it was replaced by a save.
+     */
+    chartDef() {
+      this.reloadChart();
+    }
   }
 };
 </script>

--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -105,6 +105,7 @@ export default {
     return {
       messages,
       allEventsSentinel: ALL_EVENTS,
+      loaded: false,
       chart: null,
       chartData: [],
       filterEvents: [],
@@ -135,6 +136,7 @@ export default {
       this.chartData = data;
       this.filterEvents = filterEvents;
       this.warnings = warnings;
+      this.loaded = true;
     },
 
     _makeChart() {
@@ -275,9 +277,9 @@ export default {
     },
 
     grouped() {
-      const { filteredData, chartDef, chartEnd, dateInterval } = this;
-      return groupedByInterval(filteredData, chartDef.field, chartDef.start, chartEnd,
-        dateInterval, chartDef.group);
+      const { loaded, filteredData, chartDef, chartEnd, dateInterval } = this;
+      return loaded ? groupedByInterval(filteredData, chartDef.field, chartDef.start, chartEnd,
+        dateInterval, chartDef.group) : {};
     },
 
     summary() {

--- a/js/components/ChartForm.vue
+++ b/js/components/ChartForm.vue
@@ -387,7 +387,7 @@ export default {
     },
 
     /**
-     * Resets the model on cancel.
+     * Resets the model. Used on cancel and when the `chartDef` prop is replaced.
      */
     reset() {
       const { chartDef } = this;
@@ -716,6 +716,15 @@ export default {
     submitDisabled() {
       const { isDirty, hasErrors } = this;
       return !isDirty || hasErrors;
+    }
+  },
+
+  watch: {
+    /**
+     * Watches the `chartDef` prop for changes, indicating that it was replaced by a save.
+     */
+    chartDef() {
+      this.reset();
     }
   }
 }

--- a/js/components/Vizr.vue
+++ b/js/components/Vizr.vue
@@ -6,8 +6,11 @@
       <ExampleChart v-show="noCharts"/>
       <Instructions :can-edit="canEdit" :has-charts="hasCharts"/>
 
-      <div class="error" v-if="hasConfigError">
-        {{ messages.warnings.configError }} {{ config.error.message }}
+      <div class="error" v-if="hasError">
+        {{ errorMessage }}
+        <ul v-if="hasErrorDetails">
+          <li v-for="message in errorDetails" :key="message">{{ message }}</li>
+        </ul>
       </div>
 
       <div class="vizr-charts">
@@ -17,7 +20,8 @@
                :metadata="metadata"
                :chart-def="chart"
                @delete-chart="deleteChart"
-               @toggle-legend="saveChart"/>
+               @toggle-legend="saveChart"
+               @save-chart="saveChart"/>
       </div>
 
       <div class="spacious" v-if="canEdit">
@@ -60,7 +64,8 @@ const messages = {
   },
   heading: 'Vizr Charts',
   warnings: {
-    configError: 'Project configuration could not be loaded due to an error: '
+    configError: 'Project configuration could not be loaded due to an error: ',
+    saveError: 'Your chart changes could not be saved:'
   }
 };
 
@@ -91,7 +96,9 @@ export default {
       config: {},
       loading: true,
       metadata: {},
-      newChart: newChartDefinition()
+      newChart: newChartDefinition(),
+      errorMessage: '',
+      errorDetails: []
     };
   },
 
@@ -101,53 +108,137 @@ export default {
   },
 
   methods: {
+    /**
+     * Gets project metadata and chart configuration.
+     */
     fetchConfig() {
       const { dataService } = this;
       return dataService.getProjectConfig()
-        .then(responseArray => {
-          const [ metadata, chartConfig ] = responseArray;
-          this.metadata = metadata;
-          this.config = chartConfig;
-        })
-        .catch(reason => {
-          this.config = { error: reason };
-        })
+        .then(this.captureConfig)
+        .catch(this.handleConfigError)
         .finally(() => {
           this.loading = false;
         });
     },
 
     /**
-     * Handles deleting a chart.
+     * Sets metadata and chart configuration from `fetchConfig` response.
+     * @param {Promise->Object[]} responseArray - `dataService.getProjectConfig` response
+     * @see fetchConfig
+     * @see data-service.js
      */
-    deleteChart(id) {
-      console.log(`delete chart ${id}`);
-      const { config } = this;
-      const index = config.charts.findIndex(c => c.id === id);
-      if (index >= 0) {
-        config.charts.splice(index, 1);
+    captureConfig(responseArray) {
+      const [ metadata, chartConfig ] = responseArray;
+      this.metadata = metadata;
+      this.config = chartConfig;
+    },
+
+    /**
+     * Handles rejection of the `fetchConfig` request.
+     * @param {Error} reason - the error that triggered rejection.
+     */
+    handleConfigError(reason) {
+      this.config = { error: reason };
+      this.errorMessage = messages.warnings.configError;
+      this.errorDetails = [ reason.message ];
+    },
+
+    /**
+     * Replaces chart configuration after a save request.
+     * @param {Promise->Object[]} newCharts - new chart configuration
+     */
+    replaceCharts(newCharts) {
+      const { config, charts } = this;
+      config.charts = newCharts;
+      if (newCharts.length !== charts.length) {
+        this.newChart = newChartDefinition();
       }
     },
 
     /**
+     * Handles rejection of `saveChartConfig` requests.
+     * @param {Error} reason - the reason the `saveChartConfig` request rejected.
+     * @see saveChartConfig
+     * @see data-service.js
+     */
+    handleSaveError(reason) {
+      const { message, redcapErrors } = reason;
+      this.errorMessage = messages.warnings.saveError;
+      this.errorDetails = [ message, ...redcapErrors ];
+    },
+
+    /**
+     * Constructs the new state of the chart configuration array. The old chart config is
+     * not mutated.
+     * @param {Object[]} charts - the current chart configuration array
+     * @param {Object} chartDef - the chart definition being changed (added, updated, or deleted)
+     * @param {Boolean} deleteChart - whether the chart is being deleted (default is false)
+     * @return {Object[]} a new array of chart definitions.
+     */
+    _makeNewChartsArray(charts, chartDef, deleteChart = false) {
+      const { id } = chartDef;
+      const index = charts.findIndex(c => c.id === id);
+      const isNewChart = index === -1;
+      const newCharts = Array.of(...charts);
+
+      if (isNewChart) {
+        newCharts.push(chartDef);
+      } else if (deleteChart) {
+        newCharts.splice(index, 1);
+      } else {
+        newCharts.splice(index, 1, chartDef);
+      }
+
+      return newCharts;
+    },
+
+    /**
+     * Saves updated chart configuration. On success, the old configuration is replaced.
+     * @param {Object[]} newCharts - array of new chart definitions
+     */
+    saveChartConfig(newCharts) {
+      const { dataService } = this;
+      dataService.saveChartConfig(newCharts)
+        .then(() => this.replaceCharts(newCharts))
+        .catch(this.handleSaveError);
+    },
+
+    /**
+     * Handles deleting a chart.
+     * @param {Object} chartDef - the chart definition to delete
+     */
+    deleteChart(chartDef) {
+      const { charts } = this;
+      const newCharts = this._makeNewChartsArray(charts, chartDef, true);
+      this.saveChartConfig(newCharts);
+    },
+
+    /**
      * Handles saving a new or updated chart.
+     * @param {Object} chartDef - the chart definition being added or updated
      */
     saveChart(chartDef) {
-      const { config } = this;
-      const { id } = chartDef;
-      const index = config.charts.findIndex(c => c.id === id);
-      if (index >= 0) {
-        console.log(`found existing chart at index ${index}`);
-        config.charts[index] = chartDef;
-      } else {
-        console.log(`chart ${id} is a new chart`);
-        config.charts.push(chartDef);
-        this.newChart = newChartDefinition();
-      }
+      const { charts } = this;
+      const newCharts = this._makeNewChartsArray(charts, chartDef);
+
+      // wait for the next tick so the form collapses
+      this.$nextTick(() => {
+        this.saveChartConfig(newCharts);
+      });
     }
   },
 
   computed: {
+    hasError() {
+      const { errorMessage } = this;
+      return Boolean(errorMessage);
+    },
+
+    hasErrorDetails() {
+      const { errorDetails } = this;
+      return Array.isArray(errorDetails) && errorDetails.length > 0;
+    },
+
     hasConfigError() {
       const { config } = this;
       return Boolean(config.error);

--- a/js/services/data-service.js
+++ b/js/services/data-service.js
@@ -10,7 +10,7 @@ export const ENDPOINTS = {
 };
 
 const warnings = {
-  blankDateFields: ((count) => `Ignored ${count} records with blank date field.`),
+  blankDateFields: ((count) => `Ignored ${count} ${count > 1 ? 'records' : 'record'} with blank date field.`),
   multipleEvents: 'The filter returned multiple events per record.',
   noData: 'The filter returned 0 records.',
   repeatingInstruments: 'Charts may not work as expected with repeating instruments.'
@@ -30,7 +30,7 @@ function makeWarning(key, ...rest) {
   let message;
 
   if (typeof warnings[key] === 'function') {
-    message = warnings[key].apply(rest);
+    message = warnings[key].apply(null, rest);
   } else {
     message = warnings[key];
   }

--- a/test/components/ChartForm_test.js
+++ b/test/components/ChartForm_test.js
@@ -199,7 +199,23 @@ describe('ChartForm.vue', () => {
         expect(titleInput.element.value).toEqual(exampleChart.title);
         expect(descriptionInput.element.value).toEqual(exampleChart.description);
         done();
-      })
+      });
+    });
+
+    it('resets the form when chartDef is replaced', () => {
+      const form = shallowMount(ChartForm, {
+        propsData: {
+          chartDef: exampleChart,
+          metadata: exampleMetadata
+        }
+      });
+
+      expect(form.find(selector.titleField).element.value).toEqual(exampleChart.title);
+
+      // replace the chart definition
+      form.setProps({ chartDef: emptyChart });
+
+      expect(form.find(selector.titleField).element.value).toEqual(emptyChart.title);
     });
 
     describe('validation', () => {

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -434,10 +434,10 @@ describe('Chart.vue', () => {
       expect(wrapper.emitted('toggle-legend')).toBeFalsy();
     });
 
-    it('emits an event with the chart ID when user can edit', () => {
+    it('emits an event with the chart definition when user can edit', () => {
       wrapper.find(legendToggleSelector).trigger('click');
       expect(wrapper.emitted('toggle-legend')).toBeTruthy();
-      expect(wrapper.emitted('toggle-legend')[0]).toEqual([ chartDef.id ]);
+      expect(wrapper.emitted('toggle-legend')[0]).toEqual([ chartDef ]);
     });
   });
 });

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -378,11 +378,11 @@ describe('Chart.vue', () => {
       expect(wrapper.emitted('delete-chart')).toBeFalsy();
     });
 
-    it('emits an event with the chart ID when confirmed', () => {
+    it('emits an event with the chart definition when confirmed', () => {
       spyOn(window, 'confirm').and.returnValue(true);
       wrapper.find(deleteSelector).trigger('click');
       expect(wrapper.emitted('delete-chart')).toBeTruthy();
-      expect(wrapper.emitted('delete-chart')[0]).toEqual([ exampleLongitudinalChart.id ]);
+      expect(wrapper.emitted('delete-chart')[0]).toEqual([ exampleLongitudinalChart ]);
     });
   });
 

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -303,6 +303,44 @@ describe('Chart.vue', () => {
     });
   });
 
+  describe('chartDef watcher', () => {
+    const response = JSON.parse(exampleResponses.data.longitudinal.responseText);
+    let wrapper, dataService;
+
+    beforeEach((done) => {
+      dataService = {
+        getChartData() {
+          return Promise.resolve(response);
+        }
+      };
+
+      wrapper = shallowMount(Chart, {
+        propsData: {
+          canEdit: true,
+          chartDef: exampleLongitudinalChart,
+          metadata: exampleLongitudinalMetadata
+        },
+        provide: {
+          dataService
+        }
+      });
+
+      wrapper.vm.dataPromise.then(() => done());
+    });
+
+    it('refreshes chart data when chartDef is replaced', (done) => {
+      const newChart = exampleLongitudinalChartDef('different');
+
+      spyOn(dataService, 'getChartData').and.callThrough();
+      wrapper.setProps({ chartDef: newChart });
+
+      wrapper.vm.dataPromise.then(() => {
+        expect(dataService.getChartData).toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+
   describe('chart delete link', () => {
     const response = JSON.parse(exampleResponses.data.longitudinal.responseText);
     let deleteSelector = '[data-description=delete]';

--- a/test/components/Vizr_test.js
+++ b/test/components/Vizr_test.js
@@ -23,6 +23,9 @@ function createProvideObject() {
     dataService: {
       getProjectConfig() {
         return Promise.resolve([ exampleMetadata, exampleChartConfig ]);
+      },
+      saveChartConfig() {
+        return Promise.resolve({ item_count: 1 });
       }
     }
   };
@@ -34,6 +37,7 @@ describe('Vizr.vue', () => {
   beforeEach((done) => {
     mockProvide = createProvideObject();
     spyOn(mockProvide.dataService, 'getProjectConfig').and.callThrough();
+    spyOn(mockProvide.dataService, 'saveChartConfig').and.callThrough();
 
     wrapper = shallowMount(Vizr, {
       propsData: {
@@ -99,7 +103,243 @@ describe('Vizr.vue', () => {
 
       errorWrapper.vm.configPromise.then(() => {
         expect(errorWrapper.find('.error').exists()).toBe(true);
+        expect(errorWrapper.find('button').attributes().disabled).toBeTruthy();
         done();
+      });
+    });
+  });
+
+  describe('saving a chart', () => {
+    beforeEach(() => {
+      mockProvide.dataService.saveChartConfig.calls.reset();
+    });
+
+    describe('when the chart is new', () => {
+      it('persists the new configuration', (done) => {
+        const newChart = exampleChartDef(uuid());
+        const expectedCharts = [...exampleChartConfig.charts, newChart];
+
+        wrapper.vm.saveChart(newChart);
+
+        // schedule on the task queue to allow promises to resolve
+        setTimeout(() => {
+          // new chart is added to the array
+          expect(mockProvide.dataService.saveChartConfig).toHaveBeenCalledWith(expectedCharts);
+          expect(wrapper.vm.charts).toEqual(expectedCharts);
+          done();
+        });
+      });
+    });
+
+    describe('when the chart is updated', () => {
+      it('persists the new configuration', (done) => {
+        // second chart config will be replaced
+        const updatedChart = Object.assign({}, exampleChartConfig[1]);
+        updatedChart.title = 'Different Title';
+        const expectedCharts = [exampleChartConfig.charts[0], updatedChart];
+
+        wrapper.vm.saveChart(updatedChart);
+
+        // schedule on the task queue to allow promises to resolve
+        setTimeout(() => {
+          // updated chart is replaced
+          expect(mockProvide.dataService.saveChartConfig).toHaveBeenCalledWith(expectedCharts);
+          expect(wrapper.vm.charts).toEqual(expectedCharts);
+          done();
+        });
+      });
+    });
+
+    describe('when saving fails', () => {
+      let errorWrapper;
+
+      beforeEach((done) => {
+        const provideObject = createProvideObject();
+        provideObject.dataService.saveChartConfig = () => {
+          const error = new Error('Expected to change 1 record, but 0 records changed.');
+          error.redcapErrors = ['Some error'];
+          return Promise.reject(error);
+        };
+
+        errorWrapper = shallowMount(Vizr, {
+          propsData: {
+            canEdit: true
+          },
+          provide: provideObject
+        });
+
+        errorWrapper.vm.configPromise.then(() => done());
+      });
+
+      it('displays errors', (done) => {
+        const chartDef = exampleChartConfig.charts[0];
+        errorWrapper.vm.saveChart(chartDef);
+
+        // schedule on the task queue to allow promises to resolve
+        setTimeout(() => {
+          const errorBlock = errorWrapper.find('.error');
+          // error message is displayed
+          expect(errorBlock.exists()).toBe(true);
+          // error details are displayed
+          expect(errorWrapper.find('ul').exists()).toBe(true);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('deleting a chart', () => {
+    it('persists the new configuration', (done) => {
+      mockProvide.dataService.saveChartConfig.calls.reset();
+
+      const toDelete = exampleChartConfig.charts[1];
+      const expectedCharts = exampleChartConfig.charts.slice(0, 1);
+
+      wrapper.vm.deleteChart(toDelete);
+
+      // schedule on the task queue to allow promises to resolve
+      setTimeout(() => {
+        // chart is removed
+        expect(mockProvide.dataService.saveChartConfig).toHaveBeenCalledWith(expectedCharts);
+        expect(wrapper.vm.charts).toEqual(expectedCharts);
+        done();
+      });
+    });
+  });
+
+  describe('new charts array creation', () => {
+    describe('adding new charts', () => {
+      it('adds correctly when the array is empty', () => {
+        const oldCharts = [];
+        const newChart = { id: 'new' };
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, newChart);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts).toEqual([]);
+
+        expect(output).toEqual([ newChart ]);
+      });
+
+      it('adds correctly when the array contains charts', () => {
+        const oldCharts = [{ id: 'old' }];
+        const newChart = { id: 'new' };
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, newChart);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts).toEqual([{ id: 'old' }]);
+
+        expect(output.length).toEqual(2);
+        expect(output[0]).toEqual(oldCharts[0]);
+        expect(output[1]).toEqual(newChart);
+      });
+    });
+
+    describe('replacing a chart', () => {
+      it('replaces correctly when the chart is first in the array', () => {
+        const oldCharts = [{ id: 'test', status: 'old' }];
+        const newChart = { id: 'test', status: 'new' };
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, newChart);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts).toEqual([{ id: 'test', status: 'old' }]);
+
+        expect(output.length).toEqual(1);
+        expect(output[0].status).toEqual('new');
+      });
+
+      it('replaces correctly when the chart is in the middle of the array', () => {
+        const oldCharts = [
+          { id: 'start' },
+          { id: 'test', status: 'old' },
+          { id: 'end' }
+        ];
+        const newChart = { id: 'test', status: 'new' };
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, newChart);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts[1].status).toEqual('old');
+
+        expect(output[1].status).toEqual('new');
+      });
+
+      it('replaces correctly when the chart is at the end of the array', () => {
+        const oldCharts = [
+          { id: 'start' },
+          { id: 'test', status: 'old' }
+        ];
+        const newChart = { id: 'test', status: 'new' };
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, newChart);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts[1].status).toEqual('old');
+
+        expect(output[1].status).toEqual('new');
+      });
+    });
+
+    describe('deleting a chart', () => {
+      it('deletes correctly when the chart is first in the array', () => {
+        const oldCharts = [{ id: 'test' }, { id: 'after' }];
+        const toDelete = oldCharts[0];
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, toDelete, true);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts.length).toEqual(2);
+        expect(oldCharts[0]).toEqual(toDelete);
+
+        expect(output).toEqual([{ id: 'after' }]);
+      });
+
+      it('deletes correctly when the chart is in the middle of the array', () => {
+        const oldCharts = [
+          { id: 'before' },
+          { id: 'test' },
+          { id: 'after' }
+        ];
+        const toDelete = oldCharts[1];
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, toDelete, true);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts.length).toEqual(3);
+        expect(oldCharts[1]).toEqual(toDelete);
+
+        expect(output).toEqual([{ id: 'before' }, { id: 'after' }]);
+      });
+
+      it('deletes correctly when the chart is at the end of the array', () => {
+        const oldCharts = [
+          { id: 'before' },
+          { id: 'test' }
+        ];
+        const toDelete = oldCharts[1];
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, toDelete, true);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts.length).toEqual(2);
+        expect(oldCharts[1]).toEqual(toDelete);
+
+        expect(output).toEqual([{ id: 'before' }]);
+      });
+
+      it('deletes correctly when the chart is the last chart', () => {
+        const oldCharts = [{ id: 'test' }];
+        const toDelete = oldCharts[0];
+        const output = wrapper.vm._makeNewChartsArray(oldCharts, toDelete, true);
+
+        // input array is not mutated
+        expect(output).not.toEqual(oldCharts);
+        expect(oldCharts.length).toEqual(1);
+        expect(oldCharts[0]).toEqual(toDelete);
+
+        expect(output).toEqual([]);
       });
     });
   });

--- a/test/example-ajax-responses.js
+++ b/test/example-ajax-responses.js
@@ -82,7 +82,17 @@ export const exampleResponses = {
     successful: {
       status: 200,
       contentType: 'application/json',
-      responseText: '{"item_count":1}'
+      responseText: '{"item_count": 1}'
+    },
+    failure: {
+      status: 200,
+      contentType: 'application/json',
+      responseText: '{"item_count": 0, "errors": ["Something bad happened"]}'
+    },
+    unexpected: {
+      status: 200,
+      contentType: 'application/json',
+      responseText: '{"item_count": 2}'
     }
   }
 };

--- a/test/example-chart-def.js
+++ b/test/example-chart-def.js
@@ -32,7 +32,7 @@ export function exampleNoGroupChartDef(id) {
   };
 }
 
-export function exampleLongitudinalChartDef() {
+export function exampleLongitudinalChartDef(id) {
   return {
     field: "screen_date",
     dateInterval: "week",
@@ -40,7 +40,7 @@ export function exampleLongitudinalChartDef() {
     filter: "[visit_1][dropdown]=1",
     groupFieldEvent: "enrollment",
     group: "study_clinic",
-    id: `${chartId}`,
+    id: id ? `${id}` : `${chartId}`,
     title: "Visit 1 Survey by Study Clinic",
     start: "2016-10-04",
     chartEnd: "",

--- a/test/services/data-service_test.js
+++ b/test/services/data-service_test.js
@@ -218,7 +218,7 @@ describe('data service', () => {
           service.getChartData('screen_date', { a: 'b' }).then(chartData => {
             expect(chartData.warnings).toBeDefined();
             expect(chartData.warnings.length).toEqual(1);
-            expect(chartData.warnings[0].message).toMatch('blank date field');
+            expect(chartData.warnings[0].message).toMatch('Ignored 1 record with blank date field');
 
             done();
           });

--- a/test/services/data-service_test.js
+++ b/test/services/data-service_test.js
@@ -1,5 +1,6 @@
 import 'jasmine-ajax';
 import { exampleResponses } from '../example-ajax-responses';
+import { exampleChartDef } from '../example-chart-def';
 import createDataService, { ENDPOINTS } from '@/services/data-service';
 
 const mockUrls = {};
@@ -219,6 +220,70 @@ describe('data service', () => {
             expect(chartData.warnings).toBeDefined();
             expect(chartData.warnings.length).toEqual(1);
             expect(chartData.warnings[0].message).toMatch('Ignored 1 record with blank date field');
+
+            done();
+          });
+        });
+      });
+    });
+
+    describe('saveChartConfig', () => {
+      const expectedUrl = mockUrls[ENDPOINTS.PERSISTENCE];
+      const chartConfig = [ exampleChartDef() ];
+
+      describe('successful request', () => {
+        beforeEach(() => {
+          jasmine.Ajax.stubRequest(expectedUrl)
+            .andReturn(exampleResponses.persistence.successful);
+        })
+
+        it('constructs the expected request', (done) => {
+          service.saveChartConfig(chartConfig).then(saveResponse => {
+            const request = jasmine.Ajax.requests.mostRecent();
+            expect(request.method).toEqual('POST');
+            expect(request.url).toEqual(expectedUrl);
+            expect(request.params).toEqual(JSON.stringify({ charts: chartConfig }));
+
+            // it extracts the number of records saved
+            expect(saveResponse.item_count).toEqual(1);
+            expect(saveResponse.errors).not.toBeDefined();
+
+            done();
+          });
+        });
+      });
+
+      describe('error responses', () => {
+        it('throws an error if an unexpected number of records change', (done) => {
+          jasmine.Ajax.stubRequest(expectedUrl)
+            .andReturn(exampleResponses.persistence.unexpected);
+
+          service.saveChartConfig(chartConfig).catch(reason => {
+            // it throws an error with the expected reason
+            expect(reason.message).toEqual('Expected to change 1 record, but 2 records changed.');
+
+            // it includes the REDCap errors in the error object
+            expect(reason.redcapErrors).toBeDefined();
+
+            // it provides a default errors array
+            expect(reason.redcapErrors).toEqual([]);
+
+            done();
+          });
+        });
+
+        it('throws an error if the REDCap response has errors', (done) => {
+          const failureBody = JSON.parse(exampleResponses.persistence.failure.responseText);
+          jasmine.Ajax.stubRequest(expectedUrl)
+            .andReturn(exampleResponses.persistence.failure);
+
+          service.saveChartConfig(chartConfig).catch(reason => {
+            // it throws an error with the expected reason
+            expect(reason.message).toEqual('Expected to change 1 record, but 0 records changed.');
+
+            // it includes the REDCap errors in the error object
+            expect(reason.redcapErrors).toBeDefined();
+            expect(reason.redcapErrors).toEqual(failureBody.errors)
 
             done();
           });


### PR DESCRIPTION
Implement saving chart configuration when charts are added, updated, and deleted. Fixes #25, #29.

This one is probably best read one commit at a time.