### PR TITLE
REDDEV-539 removed check for module access

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ in a time series fashion to provide additional insights about their project.
 # Vizr Installation and Upgrades
 
 See [INSTALL.md](INSTALL.md).
+
+# Vizr Permissions
+
+After installing Vizr you will need to configure the module to allow users to view, create and edit charts.
+
+First, navigate to *Control Center*, then *External Modules*, and click *Configure* for the Vizr module.
+
+Under *Module configuration permissions in projects* you have two options: *Require Project Setup/Design privilege* and *Require module-specific user privilege*. The first allows all users with *Project Design and Setup* rights full access to Vizr. They will be able to view, create, and edit charts. The second option should be used if you want some users to have view-only rights.
+
+For *Require Project Setup/Design privilege*, navigate to *User Rights*, select a user, and click *Edit user privileges*. Under *Highest level privileges* you will see *Project Design and Setup*. If this is checked the user will be able to view, create and edit charts. Notice, in this case checking *Project Design and Setup* also checks the Vizr module under the section *External Modules: Configuration Permissions* automatically - it's otherwise disabled.
+
+For *Require module-specific user privilege*, if you want a view-only user navigate to *User Rights*, select a user, and click *Edit user privileges*. Now select the Vizr module under *External Modules: Configuration Permissions* and save. If you also want that user to be able to create and edit charts you will also need to check *Project Design and Setup*. Both must be checked.
+
+If Vizr is enabled for a project, super users may view, create and edit charts in a all cases.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,12 @@ See [INSTALL.md](INSTALL.md).
 
 # Vizr Permissions
 
-After installing Vizr you will need to configure the module to allow users to view, create and edit charts.
+By default, all users of a project with Vizr enabled may view charts.
 
-First, navigate to *Control Center*, then *External Modules*, and click *Configure* for the Vizr module.
+For users that also need to create, edit, and delete charts you must give them **Project Design and Setup** rights. To do so follow these steps:
 
-Under *Module configuration permissions in projects* you have two options: *Require Project Setup/Design privilege* and *Require module-specific user privilege*. The first allows all users with *Project Design and Setup* rights full access to Vizr. They will be able to view, create, and edit charts. The second option should be used if you want some users to have view-only rights.
-
-For *Require Project Setup/Design privilege*, navigate to *User Rights*, select a user, and click *Edit user privileges*. Under *Highest level privileges* you will see *Project Design and Setup*. If this is checked the user will be able to view, create and edit charts. Notice, in this case checking *Project Design and Setup* also checks the Vizr module under the section *External Modules: Configuration Permissions* automatically - it's otherwise disabled.
-
-For *Require module-specific user privilege*, if you want a view-only user navigate to *User Rights*, select a user, and click *Edit user privileges*. Now select the Vizr module under *External Modules: Configuration Permissions* and save. If you also want that user to be able to create and edit charts you will also need to check *Project Design and Setup*. Both must be checked.
-
-If Vizr is enabled for a project, super users may view, create and edit charts in a all cases.
+* Navigate, on a project with Vizr, to **User Rights**
+* Select a user
+* Click **Edit user privileges**
+* Under **Highest level privileges** check **Project Design and Setup*
+* Save

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [INSTALL.md](INSTALL.md).
 
 # Vizr Permissions
 
-By default, all users of a project with Vizr enabled may view charts.
+All users of a project with Vizr enabled may view charts.
 
 For users that also need to create, edit, and delete charts you must give them **Project Design and Setup** rights. To do so follow these steps:
 

--- a/Vizr.php
+++ b/Vizr.php
@@ -7,19 +7,12 @@ use ExternalModules\ExternalModules;
 class Vizr extends AbstractExternalModule {
 
   /**
-   * Override to check for Vizr module rights in addition to design and
-   * super user rights checked by the parent. If a user has access to the
-   * Vizr module in User Rights they will be able to view charts. If the
-   * user has super user or design rights they will also be able to create
-   * and edit charts.
+   * Override to allow anyone with project access to be able to view Vizr charts. The
+   * user will need `Project Design and Setup` rights in order to create, edit, and
+   * delete charts.
    */
   public function redcap_module_link_check_display($project_id, $link) {
-    $rights = \REDCap::getUserRights(USERID);
-    if ($this->hasVizrUserRights($rights)) {
-      return $link;
-    } else {
-      return parent::redcap_module_link_check_display($project_id, $link);
-    }
+    return $link;
   }
 
   /**
@@ -31,7 +24,6 @@ class Vizr extends AbstractExternalModule {
     return !empty($rights) && is_array($user_module_config)
         && in_array($this->PREFIX, $user_module_config);
   }
-
 
   /**
    * Checks to see if a user has design rights for the current project.

--- a/Vizr.php
+++ b/Vizr.php
@@ -7,6 +7,33 @@ use ExternalModules\ExternalModules;
 class Vizr extends AbstractExternalModule {
 
   /**
+   * Override to check for Vizr module rights in addition to design and
+   * super user rights checked by the parent. If a user has access to the
+   * Vizr module in User Rights they will be able to view charts. If the
+   * user has super user or design rights they will also be able to create
+   * and edit charts.
+   */
+  public function redcap_module_link_check_display($project_id, $link) {
+    $rights = \REDCap::getUserRights(USERID);
+    if ($this->hasVizrUserRights($rights)) {
+      return $link;
+    } else {
+      return parent::redcap_module_link_check_display($project_id, $link);
+    }
+  }
+
+  /**
+   * Checks to see if a user has module rights for Vizr on the current project.
+   * @param array $rights Array of user rights from <code>REDCap::getUserRights</code>.
+   */
+  public function hasVizrUserRights($rights) {
+    $user_module_config = $rights[USERID]['external_module_config'];
+    return !empty($rights) && is_array($user_module_config)
+        && in_array($this->PREFIX, $user_module_config);
+  }
+
+
+  /**
    * Checks to see if a user has design rights for the current project.
    * @param array $rights Array of user rights from <code>REDCap::getUserRights</code>.
    */
@@ -15,8 +42,8 @@ class Vizr extends AbstractExternalModule {
   }
 
   /**
-   * Checks to see if the user can edit charts. A user can edit charts if they
-   * are a super user or have design or user rights for the vizr module.
+   * Checks to see if the user can edit charts in Vizr. A user can edit charts if they
+   * are a super user or have design rights.
    */
   public function canEditVizrCharts() {
     $rights = \REDCap::getUserRights(USERID);

--- a/Vizr.php
+++ b/Vizr.php
@@ -7,30 +7,6 @@ use ExternalModules\ExternalModules;
 class Vizr extends AbstractExternalModule {
 
   /**
-   * Override to check for Vizr User Rights. Else returns the parent value
-   * which checks for design rights.
-   */
-  public function redcap_module_link_check_display($project_id, $link) {
-    $rights = \REDCap::getUserRights(USERID);
-    if ($this->hasVizrUserRights($rights)) {
-      return $link;
-    } else {
-      return parent::redcap_module_link_check_display($project_id, $link);
-    }
-  }
-
-  /**
-   * Checks to see if a user has user rights for the Vizr external module on
-   * the current project.
-   * @param array $rights Array of user rights from <code>REDCap::getUserRights</code>.
-   */
-  public function hasVizrUserRights($rights) {
-    $user_module_config = $rights[USERID]['external_module_config'];
-    return !empty($rights) && is_array($user_module_config)
-        && in_array($this->PREFIX, $user_module_config);
-  }
-
-  /**
    * Checks to see if a user has design rights for the current project.
    * @param array $rights Array of user rights from <code>REDCap::getUserRights</code>.
    */
@@ -44,7 +20,7 @@ class Vizr extends AbstractExternalModule {
    */
   public function canEditVizrCharts() {
     $rights = \REDCap::getUserRights(USERID);
-    return SUPER_USER || $this->hasDesignRights($rights) || $this->hasVizrUserRights($rights);
+    return SUPER_USER || $this->hasDesignRights($rights);
   }
 
 }

--- a/config.json
+++ b/config.json
@@ -41,13 +41,6 @@
   "permissions": [
     "select_data"
   ],
-  "project-settings": [
-    {
-      "key": "vizr-descriptive",
-      "name": "To configure a chart, click the Vizr link under <strong>External Modules</strong> on the left navigation bar. On that page there's a link titled \"Vizr charts are configured\" which contains documentation for building charts.",
-      "type": "descriptive"
-    }
-  ],
   "links": {
     "project": [
       {


### PR DESCRIPTION
This reverts to the previous permission model.

A user can only edit charts if they are a super user or have design rights.

For a user to view charts they must have design rights, or have the Vizr
module checked on the User Rights page. For the later, the module must
be configured to 'Require module-specific user privilege'.