### PR TITLE
REDDEV-539 save fix

### DIFF
--- a/lib/persist.php
+++ b/lib/persist.php
@@ -91,10 +91,10 @@ if (inputIsValid($data)) {
     sanitizeChartConfig($data->charts);
     if ($module->canEditVizrCharts()) {
       $module->setProjectSetting('chart-definitions', $data->charts);
+      $response->item_count = 1;
     } else {
       $response->errors = array("You do not have permission to modify chart definitions.");
     }
-    $response->item_count = 1;
   } catch (Exception $e) {
     error_log("Vizr caught an exception persisting configuration for PID $project_id: " . $e->getMessage());
     $response->errors = array("The settings could not be saved due to an error.");


### PR DESCRIPTION
This fixes an issue where users couldn't persist chart definitions. I would have caught this in the last PR had I created a new user. The current bug in REDCap that doesn't remove module specific permissions bit me because my basic user still had module rights from the previous round of testing which can't be removed as of yet. I noticed this method, `disableUserBasedSettingPermissions`, yesterday so it was easy to patch. Removing REDCap's user specific permission model does mean that we now how to manage our own permissions.