### PR TITLE
Form error styling

### DIFF
--- a/js/components/ChartForm.vue
+++ b/js/components/ChartForm.vue
@@ -141,10 +141,8 @@
           </div>
         </fieldset>
 
-        <div class="form-group has-error save-warning" v-if="hasErrors">
-          <div class="help-block error-help">
-            {{ messages.validation.cannotSave }}
-          </div>
+        <div class="alert alert-danger" role="alert" v-if="hasErrors">
+          {{ messages.validation.cannotSave }}
         </div>
 
         <button

--- a/lib/vizr.css
+++ b/lib/vizr.css
@@ -141,12 +141,31 @@
 	margin-bottom: 15px;
 }
 
+.has-error .form-control {
+  border-color: #a94442;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+}
+.has-error .error-help {
+  color: #a94442;
+  margin-top: 0.2rem;
+  margin-left: 0.5rem;
+}
+
+.has-error .input-group .input-group-append .input-group-text {
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #a94442;
+}
 .error {
 	color: #a94442;
 }
+.alert-danger {
+	/* override redcap's override */
+	border-color: #f5c6cb !important;
+}
 .alert-warning {
 	/* override redcap's override */
-	border-color: #ffeeba !important;	
+	border-color: #ffeeba !important;
 }
 .alert-info {
 	/* override redcap's override */


### PR DESCRIPTION
reddev-570 ; Adds back error styling in forms, which was removed in the upgrade from Bootstrap 3 to Bootstrap 4.