### PR TITLE
Update jQuery For Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5581,9 +5581,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
       "dev": true
     },
     "js-base64": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "html-webpack-plugin": "^3.2.0",
     "jasmine-ajax": "^3.3.1",
     "jasmine-core": "^2.8.0",
-    "jquery": "~1.12.0",
+    "jquery": "~3.3.1",
     "karma": "^3.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-cli": "^1.0.1",


### PR DESCRIPTION
Update the version of jQuery used by the tests to match recent releases of REDCap. This removes a warning about a vulnerable dependency, but it should have no effect in production, because jQuery is marked external in Webpack config.