### PR TITLE
REDDEV-637 Allow non-standard external module locations

### DIFF
--- a/lib/chart_defs.php
+++ b/lib/chart_defs.php
@@ -6,9 +6,6 @@
  */
 header('Content-Type: application/json');
 
-// Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
-require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
-
 $defs_object = new stdClass();
 
 // NOTE: pid must be appended to the query url for this to be treated as a project-level request

--- a/lib/data.php
+++ b/lib/data.php
@@ -35,9 +35,6 @@
 
 header('Content-Type: application/json');
 
-// Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
-require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
-
 /**
  * Filter the input
  */

--- a/lib/main.tmpl
+++ b/lib/main.tmpl
@@ -14,8 +14,6 @@ $noAuth = false;
 // If true, the URL will be in the API format and will not include the REDCap version in the URL.
 $useApiEndpoint = true;
 
-// Call the REDCap Connect file in the main "redcap" directory
-require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 require_once dirname(realpath(__FILE__)) . '/permissions.php';
 
 // Display the project header

--- a/lib/metadata.php
+++ b/lib/metadata.php
@@ -17,9 +17,6 @@
 
 header('Content-Type: application/json');
 
-// Call the REDCap Connect file in the main "redcap" directory; enforces permissions.
-require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
-
 $metadata_object = new stdClass();
 $record_id_field = REDCap::getRecordIdField();
 $data_dictionary = json_decode(REDCap::getDataDictionary('json'));
@@ -46,9 +43,9 @@ $metadata_object->recordIdField = $record_id_field;
 $metadata_object->dataDictionary = $data_dictionary;
 $metadata_object->events = $event_map;
 if (REDCap::versionCompare ( REDCAP_VERSION , '8.7.1', '<')) {
-	$metadata_object->bootstrapVersion = 3;	
+	$metadata_object->bootstrapVersion = 3;
 } else {
-	$metadata_object->bootstrapVersion = 4;	
+	$metadata_object->bootstrapVersion = 4;
 }
 
 print json_encode($metadata_object);

--- a/lib/permissions.php
+++ b/lib/permissions.php
@@ -4,7 +4,5 @@
  * DESCRIPTION: Sets variables indicating whether or not the current user has
  * edit permissions to the Vizr external module in the current project.
  */
-// NOTE: The following line should be included in the calling page.
-// require_once "../../../redcap_connect.php";
 
 $can_edit = $module->canEditVizrCharts();

--- a/lib/persist.php
+++ b/lib/persist.php
@@ -6,8 +6,6 @@
  * rights for the current project.
  */
 
-// Call the REDCap Connect file in the main "redcap" directory
-require_once dirname(realpath(__FILE__)) . '/../../../redcap_connect.php';
 require_once dirname(realpath(__FILE__)) . '/permissions.php';
 
 // Allows project settings to be saved when users don't have explicit module permission.


### PR DESCRIPTION
This fix accomodates instances where the external modules location is
not the default location. When Vizr was a plugin it was dependent on the
`redcap_connect.php` file to be in a known location, but the external
module API automatically provides this file so it can be removed as a
dependency in the PHP files.