### PR TITLE
REDDEV-654 Vizr blank if using API URL at OHSU

### DIFF
--- a/lib/main.tmpl
+++ b/lib/main.tmpl
@@ -12,7 +12,7 @@
  // If noAuth is true, NOAUTH will be appended to the URL. The page will be public.
 $noAuth = false;
 // If true, the URL will be in the API format and will not include the REDCap version in the URL.
-$useApiEndpoint = true;
+$useApiEndpoint = false;
 
 require_once dirname(realpath(__FILE__)) . '/permissions.php';
 


### PR DESCRIPTION
Because we block the API URL outside OHSU, Vizr fails to load and
results in a blank page. Changing the configuration moves it to use the
the regular REDCap URL with versions.