### PR TITLE
Vue Test Deprecations

### DIFF
--- a/test/components/ChartForm_test.js
+++ b/test/components/ChartForm_test.js
@@ -198,7 +198,10 @@ describe('ChartForm.vue', () => {
       });
 
       // change the group
-      form.findAll(`${selector.groupingFieldSelect} > option`).at(0).setSelected();
+      const firstGroupingField = form
+        .findAll(`${selector.groupingFieldSelect} > option`)
+        .at(0);
+      form.find(selector.groupingFieldSelect).setValue(firstGroupingField.element.value);
 
       expect(form.vm.model.group).toEqual('');
       expect(form.vm.model.targets).toEqual(defaultTargetsObject());
@@ -213,7 +216,10 @@ describe('ChartForm.vue', () => {
       });
 
       // change the group and target
-      form.findAll(`${selector.groupingFieldSelect} > option`).at(0).setSelected();
+      const firstGroupingField = form
+        .findAll(`${selector.groupingFieldSelect} > option`)
+        .at(0);
+      form.find(selector.groupingFieldSelect).setValue(firstGroupingField.element.value);
       await Vue.nextTick();
       form.find('input[name=target_count]').setValue('60');
       await Vue.nextTick();
@@ -407,23 +413,24 @@ describe('ChartForm.vue', () => {
       expect(dateFieldOptions.at(1).text().trim()).toEqual('survey_date (Survey date)');
     });
 
-    it('changes date field options when event is changed and removes selection', done => {
+    it('changes date field options when event is changed and removes selection', async () => {
       const dateFieldEventOptions = wrapper.findAll(
         `${selector.dateFieldEventSelect} > option`
       );
-      dateFieldEventOptions.at(1).setSelected();
 
-      wrapper.vm.$nextTick(() => {
-        expect(wrapper.vm.model.field).toEqual('');
-        const dateFieldOptions = wrapper.findAll(`${selector.dateFieldSelect} > option`);
-        // 3 options plus prompt
-        expect(dateFieldOptions.length).toEqual(4);
-        // sorted by label
-        expect(dateFieldOptions.at(1).text().trim()).toEqual(
-          'enroll_date (Enrollment date)'
-        );
-        done();
-      });
+      wrapper
+        .find(selector.dateFieldEventSelect)
+        .setValue(dateFieldEventOptions.at(1).element.value);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.model.field).toEqual('');
+      const dateFieldOptions = wrapper.findAll(`${selector.dateFieldSelect} > option`);
+      // 3 options plus prompt
+      expect(dateFieldOptions.length).toEqual(4);
+      // sorted by label
+      expect(dateFieldOptions.at(1).text().trim()).toEqual(
+        'enroll_date (Enrollment date)'
+      );
     });
 
     it('creates the expected grouping field options for the selected event', () => {
@@ -436,25 +443,24 @@ describe('ChartForm.vue', () => {
       expect(groupFieldOptions.at(2).text().trim()).toEqual('screened (Screened)');
     });
 
-    it('changes grouping options when event is changed and removes selection', done => {
+    it('changes grouping options when event is changed and removes selection', async () => {
       const groupFieldEventOptions = wrapper.findAll(
         `${selector.groupFieldEventSelect} > option`
       );
-      groupFieldEventOptions.at(3).setSelected();
 
-      wrapper.vm.$nextTick(() => {
-        expect(wrapper.vm.model.group).toEqual('');
-        const groupFieldOptions = wrapper.findAll(
-          `${selector.groupingFieldSelect} > option`
-        );
-        // 2 options plus prompt
-        expect(groupFieldOptions.length).toEqual(3);
-        // sorted by label
-        expect(groupFieldOptions.at(1).text().trim()).toEqual(
-          'dropdown (Dropdown field)'
-        );
-        done();
-      });
+      wrapper
+        .find(selector.groupFieldEventSelect)
+        .setValue(groupFieldEventOptions.at(3).element.value);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.model.group).toEqual('');
+      const groupFieldOptions = wrapper.findAll(
+        `${selector.groupingFieldSelect} > option`
+      );
+      // 2 options plus prompt
+      expect(groupFieldOptions.length).toEqual(3);
+      // sorted by label
+      expect(groupFieldOptions.at(1).text().trim()).toEqual('dropdown (Dropdown field)');
     });
 
     describe('longitudinalValidation', () => {
@@ -479,7 +485,7 @@ describe('ChartForm.vue', () => {
 
       it('disables saving when date field event is missing', async () => {
         // unselect the event
-        form.findAll(`${selector.dateFieldEventSelect} > option`).at(0).setSelected();
+        form.find(selector.dateFieldEventSelect).setValue('');
         await Vue.nextTick();
 
         // date event is invalid
@@ -491,8 +497,9 @@ describe('ChartForm.vue', () => {
 
       it('validates date field event selected if date field selected', async () => {
         // Unselect date field event - select date field
-        form.findAll(`${selector.dateFieldEventSelect} > option`).at(0).setSelected();
-        form.findAll(`${selector.dateFieldSelect} > option`).at(1).setSelected();
+        form.find(selector.dateFieldEventSelect).setValue('');
+        const dateFieldOption = form.findAll(`${selector.dateFieldSelect} > option`).at(1);
+        form.find(selector.dateFieldSelect).setValue(dateFieldOption.element.value);
         await Vue.nextTick();
 
         // date event and date field are invalid
@@ -505,8 +512,9 @@ describe('ChartForm.vue', () => {
 
       it('validates group event selected if group selected', async () => {
         // Unselect group event - select group field
-        form.findAll(`${selector.groupFieldEventSelect} > option`).at(0).setSelected();
-        form.findAll(`${selector.groupingFieldSelect} > option`).at(1).setSelected();
+        form.find(selector.groupFieldEventSelect).setValue('');
+        const groupFieldOption = form.findAll(`${selector.groupingFieldSelect} > option`).at(1);
+        form.find(selector.groupingFieldSelect).setValue(groupFieldOption.element.value);
         await Vue.nextTick();
 
         expect(form.findAll(selector.validationError).length).toEqual(1);

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -56,7 +56,7 @@ describe('Chart.vue', () => {
       });
 
       it('does not show live event filter', () => {
-        expect(wrapper.find('.vizr-event-select').isEmpty()).toBe(true);
+        expect(wrapper.find('.vizr-event-select select').exists()).toBeFalse();
       });
 
       it('shows a chart summary', () => {
@@ -116,7 +116,7 @@ describe('Chart.vue', () => {
 
       it('displays the warnings', () => {
         const errorElement = wrapper.find('.warning');
-        expect(errorElement.isEmpty()).toBe(false);
+        expect(errorElement.exists()).toBeTrue();
         expect(errorElement.text()).toMatch(response.warnings[0].message);
       });
     });
@@ -158,7 +158,7 @@ describe('Chart.vue', () => {
       });
 
       it('does not show live event filter', () => {
-        expect(wrapper.find('.vizr-event-select').isEmpty()).toBe(true);
+        expect(wrapper.find('.vizr-event-select select').exists()).toBeFalse();
       });
 
       it('shows a chart summary', () => {
@@ -225,7 +225,7 @@ describe('Chart.vue', () => {
 
       it('displays the warnings', () => {
         const errorElement = wrapper.find('.warning');
-        expect(errorElement.isEmpty()).toBe(false);
+        expect(errorElement.exists()).toBeTrue();
         expect(errorElement.text()).toMatch(response.warnings[0].message);
       });
     });
@@ -256,7 +256,7 @@ describe('Chart.vue', () => {
       });
 
       it('shows live event filter', () => {
-        expect(wrapper.find('.vizr-event-select').isEmpty()).toBe(false);
+        expect(wrapper.find('.vizr-event-select select').exists()).toBeTrue();
       });
 
       it('filters the data when event is selected', async () => {

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -52,7 +52,7 @@ describe('Chart.vue', () => {
       });
 
       it('shows no errors', () => {
-        expect(wrapper.contains('.warning')).toBe(false);
+        expect(wrapper.find('.warning').exists()).toBeFalse();
       });
 
       it('does not show live event filter', () => {
@@ -60,11 +60,11 @@ describe('Chart.vue', () => {
       });
 
       it('shows a chart summary', () => {
-        expect(wrapper.contains(ChartSummary)).toBe(true);
+        expect(wrapper.findComponent(ChartSummary).exists()).toBeTrue();
       });
 
       it('shows a chart', () => {
-        expect(wrapper.contains('.vizr-chart canvas')).toBe(true);
+        expect(wrapper.find('.vizr-chart canvas').exists()).toBeTrue();
         expect(wrapper.findAll('[data-description=toggle-legend]').length).toEqual(1);
       });
 
@@ -154,7 +154,7 @@ describe('Chart.vue', () => {
       });
 
       it('shows no errors', () => {
-        expect(wrapper.contains('.warning')).toBe(false);
+        expect(wrapper.find('.warning').exists()).toBeFalse();
       });
 
       it('does not show live event filter', () => {
@@ -162,11 +162,11 @@ describe('Chart.vue', () => {
       });
 
       it('shows a chart summary', () => {
-        expect(wrapper.contains(ChartSummary)).toBe(true);
+        expect(wrapper.findComponent(ChartSummary).exists()).toBeTrue();
       });
 
       it('shows a chart', () => {
-        expect(wrapper.contains('.vizr-chart canvas')).toBe(true);
+        expect(wrapper.find('.vizr-chart canvas').exists()).toBeTrue();
         expect(wrapper.findAll('[data-description=toggle-legend]').length).toEqual(1);
       });
 

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -259,7 +259,7 @@ describe('Chart.vue', () => {
         expect(wrapper.find('.vizr-event-select').isEmpty()).toBe(false);
       });
 
-      it('filters the data when event is selected', () => {
+      it('filters the data when event is selected', async () => {
         const allEventData = wrapper.vm.chartData;
         const allEventGrouped = wrapper.vm.grouped;
         const allEventSummary = wrapper.vm.summary;
@@ -268,13 +268,17 @@ describe('Chart.vue', () => {
         expect(wrapper.vm.filteredData).toEqual(allEventData);
 
         // Select an event - data should change
-        wrapper.find('option[value=visit_1]').setSelected();
+        const visit1Option = wrapper.find('option[value=visit_1]');
+        wrapper.find('select').setValue(visit1Option.element.value);
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.filteredData).not.toEqual(allEventData);
         expect(wrapper.vm.grouped).not.toEqual(allEventGrouped);
         expect(wrapper.vm.summary).not.toEqual(allEventSummary);
 
         // Select all events again - data should revert
-        wrapper.findAll('option').at(0).setSelected();
+        const allEventsOption = wrapper.findAll('option').at(0);
+        wrapper.find('select').setValue(allEventsOption.element.value);
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.filteredData).toEqual(allEventData);
         expect(wrapper.vm.grouped).toEqual(allEventGrouped);
         expect(wrapper.vm.summary).toEqual(allEventSummary);

--- a/test/components/Vizr_test.js
+++ b/test/components/Vizr_test.js
@@ -68,11 +68,13 @@ describe('Vizr.vue', () => {
   });
 
   it('shows the example chart if no charts are defined yet', async () => {
-    expect(wrapper.findComponent(ExampleChart).isVisible()).toBe(false);
+    let style = wrapper.findComponent(ExampleChart).element.style;
+    expect(style.display).toEqual('none');
 
     wrapper.setData({ config: { charts: [] } });
     await Vue.nextTick();
-    expect(wrapper.findComponent(ExampleChart).isVisible()).toBe(true);
+    style = wrapper.findComponent(ExampleChart).element.style;
+    expect(style.display).not.toEqual('none');
   });
 
   describe('when the user can edit', () => {

--- a/test/components/Vizr_test.js
+++ b/test/components/Vizr_test.js
@@ -59,20 +59,20 @@ describe('Vizr.vue', () => {
     const heading = wrapper.find('h1');
     expect(heading.text()).toBe('Vizr Charts');
 
-    expect(wrapper.find(Instructions).exists()).toBe(true);
-    expect(wrapper.find(ExampleChart).exists()).toBe(true);
-    expect(wrapper.find(VizrVersion).exists()).toBe(true);
+    expect(wrapper.findComponent(Instructions).exists()).toBe(true);
+    expect(wrapper.findComponent(ExampleChart).exists()).toBe(true);
+    expect(wrapper.findComponent(VizrVersion).exists()).toBe(true);
 
     // renders a chart component for each chart
-    expect(wrapper.findAll(Chart).length).toEqual(exampleChartConfig.charts.length);
+    expect(wrapper.findAllComponents(Chart).length).toEqual(exampleChartConfig.charts.length);
   });
 
   it('shows the example chart if no charts are defined yet', async () => {
-    expect(wrapper.find(ExampleChart).isVisible()).toBe(false);
+    expect(wrapper.findComponent(ExampleChart).isVisible()).toBe(false);
 
     wrapper.setData({ config: { charts: [] } });
     await Vue.nextTick();
-    expect(wrapper.find(ExampleChart).isVisible()).toBe(true);
+    expect(wrapper.findComponent(ExampleChart).isVisible()).toBe(true);
   });
 
   describe('when the user can edit', () => {


### PR DESCRIPTION
Replace deprecated Vue Test Utils functions with equivalent calls that aren't deprecated. There are still deprecations related to how we're mocking calls to `debounce` that I haven't figured out yet, which will be a subsequent PR.