### PR TITLE
Run Webpack build in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,5 @@ jobs:
       with:
         node-version: 12.x
     - run: npm install
+    - run: npm run build
     - run: npm run test-ci


### PR DESCRIPTION
Run the Webpack build in CI to catch regressions caused by updates. This should make it easier to decide whether to merge Dependabot updates to build tooling.