### PR TITLE
Async test fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2542,9 +2542,9 @@
       }
     },
     "@vue/test-utils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.2.tgz",
-      "integrity": "sha512-utbIL7zn9c+SjhybPwh48lpWCiluFCbP1yyRNAy1fQsw/6hiNFioaWy05FoVAFIZXC5WwBf+5r4ypfM1j/nI4A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.1.3.tgz",
+      "integrity": "sha512-BAY1Cwe9JpkJseimC295EW3YlAmgIJI9OPkg2FSP62+PHZooB0B+wceDi9TYyU57oqzL0yLbcP73JKFpKiLc9A==",
       "dev": true,
       "requires": {
         "dom-event-types": "^1.0.0",
@@ -4998,9 +4998,9 @@
       "dev": true
     },
     "js-beautify": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.0.tgz",
-      "integrity": "sha512-/Tbp1OVzZjbwzwJQFIlYLm9eWQ+3aYbBXLSaqb1mEJzhcQAfrqMMQYtjb6io+U6KpD0ID4F+Id3/xcjH3l/sqA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.5.tgz",
+      "integrity": "sha512-MsXlH6Z/BiRYSkSRW3clNDqDjSpiSNOiG8xYVUBXt4k0LnGvDhlTGOlHX1VFtAdoLmtwjxMG5qiWKy/g+Ipv5w==",
       "dev": true,
       "requires": {
         "config-chain": "^1.1.12",
@@ -5008,14 +5008,6 @@
         "glob": "^7.1.3",
         "mkdirp": "^1.0.4",
         "nopt": "^5.0.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        }
       }
     },
     "js-tokens": {
@@ -5428,6 +5420,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
     "moment": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4455,6 +4455,12 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
+    "flush-promises": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz",
+      "integrity": "sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.13.8",
     "@babel/plugin-transform-runtime": "^7.13.9",
     "@babel/preset-env": "^7.13.9",
-    "@vue/test-utils": "^1.1.2",
+    "@vue/test-utils": "^1.1.3",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "chart.js": "^2.9.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^7.21.0",
     "eslint-plugin-vue": "^7.6.0",
     "file-loader": "^6.2.0",
+    "flush-promises": "^1.0.2",
     "git-repo-info": "^2.1.1",
     "html-webpack-plugin": "5.2.0",
     "jasmine-ajax": "^4.0.0",

--- a/test/components/ChartForm_test.js
+++ b/test/components/ChartForm_test.js
@@ -72,7 +72,7 @@ describe('ChartForm.vue', () => {
       expect(groupFieldOptions.at(1).text().trim()).toEqual('dropdown (Dropdown field)');
     });
 
-    it('initializes form inputs from the chart definition', done => {
+    it('initializes form inputs from the chart definition', async () => {
       // create an initialized form
       const withData = shallowMount(ChartForm, {
         propsData: {
@@ -82,45 +82,42 @@ describe('ChartForm.vue', () => {
       });
 
       // wait a tick for children to update
-      withData.vm.$nextTick(() => {
-        expect(withData.find(selector.titleField).element.value).toEqual(
-          exampleChart.title
-        );
-        expect(withData.find(selector.descriptionField).element.value).toEqual(
-          exampleChart.description
-        );
-        expect(withData.find(selector.dateFieldSelect).element.value).toEqual(
-          exampleChart.field
-        );
-        expect(withData.find('textarea[name=filter]').element.value).toEqual(
-          exampleChart.filter
-        );
-        expect(withData.find(selector.groupingFieldSelect).element.value).toEqual(
-          exampleChart.group
-        );
+      await Vue.nextTick();
+      expect(withData.find(selector.titleField).element.value).toEqual(
+        exampleChart.title
+      );
+      expect(withData.find(selector.descriptionField).element.value).toEqual(
+        exampleChart.description
+      );
+      expect(withData.find(selector.dateFieldSelect).element.value).toEqual(
+        exampleChart.field
+      );
+      expect(withData.find('textarea[name=filter]').element.value).toEqual(
+        exampleChart.filter
+      );
+      expect(withData.find(selector.groupingFieldSelect).element.value).toEqual(
+        exampleChart.group
+      );
 
-        // dates are converted to MM/DD/YYYY format for display
-        expect(withData.find(selector.startDateField).element.value).toEqual(
-          '10/04/2016'
-        );
-        expect(withData.find(selector.endDateField).element.value).toEqual('06/04/2017');
-        expect(withData.find(selector.targetDateField).element.value).toEqual(
-          '02/25/2017'
-        );
+      // dates are converted to MM/DD/YYYY format for display
+      expect(withData.find(selector.startDateField).element.value).toEqual(
+        '10/04/2016'
+      );
+      expect(withData.find(selector.endDateField).element.value).toEqual('06/04/2017');
+      expect(withData.find(selector.targetDateField).element.value).toEqual(
+        '02/25/2017'
+      );
 
-        // group targets are initialized
-        expect(withData.find('input[name=group_target__Bend]').element.value).toEqual(
-          '20'
-        );
-        expect(withData.find('input[name=group_target__Eugene]').element.value).toEqual(
-          '20'
-        );
-        expect(withData.find('input[name=group_target__Portland]').element.value).toEqual(
-          '20'
-        );
-
-        done();
-      });
+      // group targets are initialized
+      expect(withData.find('input[name=group_target__Bend]').element.value).toEqual(
+        '20'
+      );
+      expect(withData.find('input[name=group_target__Eugene]').element.value).toEqual(
+        '20'
+      );
+      expect(withData.find('input[name=group_target__Portland]').element.value).toEqual(
+        '20'
+      );
     });
 
     it('emits an event with chart config when the save button is clicked', async () => {
@@ -133,8 +130,7 @@ describe('ChartForm.vue', () => {
 
       withValidData.vm.isDirty = true;
       await Vue.nextTick();
-      withValidData.find(selector.saveButton).trigger('click');
-      await Vue.nextTick();
+      await withValidData.find(selector.saveButton).trigger('click');
 
       expect(withValidData.emitted('save-chart')).toBeDefined();
       expect(withValidData.emitted('save-chart')[0]).toEqual([exampleChart]);
@@ -157,12 +153,9 @@ describe('ChartForm.vue', () => {
       });
 
       // add HTML to title and description
-      form.find(selector.titleField).setValue('Chart Title <a href="#">Boop</a>');
-      await Vue.nextTick();
-      form.find(selector.descriptionField).setValue('<script>alert("hello");</script>');
-      await Vue.nextTick();
-      form.find(selector.saveButton).trigger('click');
-      await Vue.nextTick();
+      await form.find(selector.titleField).setValue('Chart Title <a href="#">Boop</a>');
+      await form.find(selector.descriptionField).setValue('<script>alert("hello");</script>');
+      await form.find(selector.saveButton).trigger('click');
 
       expect(form.emitted('save-chart')).toBeDefined();
 
@@ -182,14 +175,13 @@ describe('ChartForm.vue', () => {
       expect(form.find(selector.targetTotalSpan).text()).toMatch(/Total:\s+60/);
 
       // change the target
-      form.find('input[name=group_target__Bend]').setValue('30');
-      await Vue.nextTick();
+      await form.find('input[name=group_target__Bend]').setValue('30');
 
       expect(form.vm.model.targets).toEqual({ Portland: 20, Bend: 30, Eugene: 20 });
       expect(form.find(selector.targetTotalSpan).text()).toMatch(/Total:\s+70/);
     });
 
-    it('nullifies the targets when group is changed', () => {
+    it('nullifies the targets when group is changed', async () => {
       const form = shallowMount(ChartForm, {
         propsData: {
           chartDef: exampleChart,
@@ -201,7 +193,7 @@ describe('ChartForm.vue', () => {
       const firstGroupingField = form
         .findAll(`${selector.groupingFieldSelect} > option`)
         .at(0);
-      form.find(selector.groupingFieldSelect).setValue(firstGroupingField.element.value);
+      await form.find(selector.groupingFieldSelect).setValue(firstGroupingField.element.value);
 
       expect(form.vm.model.group).toEqual('');
       expect(form.vm.model.targets).toEqual(defaultTargetsObject());
@@ -219,26 +211,24 @@ describe('ChartForm.vue', () => {
       const firstGroupingField = form
         .findAll(`${selector.groupingFieldSelect} > option`)
         .at(0);
-      form.find(selector.groupingFieldSelect).setValue(firstGroupingField.element.value);
-      await Vue.nextTick();
-      form.find('input[name=target_count]').setValue('60');
-      await Vue.nextTick();
+      await form.find(selector.groupingFieldSelect).setValue(firstGroupingField.element.value);
+      await form.find('input[name=target_count]').setValue('60');
 
       expect(form.vm.model.targets).toEqual({ [noGroupsLabel]: 60 });
     });
 
-    it('converts dates to ISO format when updating the model', () => {
+    it('converts dates to ISO format when updating the model', async () => {
       // save updated dates
-      wrapper.find(selector.startDateField).setValue('03/04/2016');
-      wrapper.find(selector.targetDateField).setValue('04/05/2017');
-      wrapper.find(selector.endDateField).setValue('05/12/2017');
+      await wrapper.find(selector.startDateField).setValue('03/04/2016');
+      await wrapper.find(selector.targetDateField).setValue('04/05/2017');
+      await wrapper.find(selector.endDateField).setValue('05/12/2017');
 
       expect(wrapper.vm.model.start).toEqual('2016-03-04');
       expect(wrapper.vm.model.end).toEqual('2017-04-05');
       expect(wrapper.vm.model.chartEnd).toEqual('2017-05-12');
     });
 
-    it('resets the form on cancel', done => {
+    it('resets the form on cancel', async () => {
       const withData = shallowMount(ChartForm, {
         propsData: {
           chartDef: exampleChart,
@@ -248,26 +238,22 @@ describe('ChartForm.vue', () => {
 
       // change the title
       let titleInput = withData.find(selector.titleField);
-      titleInput.setValue('New title');
+      await titleInput.setValue('New title');
       expect(withData.vm.model.title).toEqual('New title');
 
       let descriptionInput = withData.find(selector.descriptionField);
-      descriptionInput.setValue('New description');
+      await descriptionInput.setValue('New description');
       expect(withData.vm.model.description).toEqual('New description');
       expect(withData.vm.model).not.toEqual(withData.vm.chartDef);
 
       // roll back changes
-      withData.find(selector.cancelButton).trigger('click');
+      await withData.find(selector.cancelButton).trigger('click');
       expect(withData.vm.model).toEqual(withData.vm.chartDef);
 
-      // wait for children to update
-      withData.vm.$nextTick(() => {
-        titleInput = withData.find(selector.titleField);
-        descriptionInput = withData.find(selector.descriptionField);
-        expect(titleInput.element.value).toEqual(exampleChart.title);
-        expect(descriptionInput.element.value).toEqual(exampleChart.description);
-        done();
-      });
+      titleInput = withData.find(selector.titleField);
+      descriptionInput = withData.find(selector.descriptionField);
+      expect(titleInput.element.value).toEqual(exampleChart.title);
+      expect(descriptionInput.element.value).toEqual(exampleChart.description);
     });
 
     it('resets the form when chartDef is replaced', async () => {
@@ -281,8 +267,7 @@ describe('ChartForm.vue', () => {
       expect(form.find(selector.titleField).element.value).toEqual(exampleChart.title);
 
       // replace the chart definition
-      form.setProps({ chartDef: emptyChart });
-      await Vue.nextTick();
+      await form.setProps({ chartDef: emptyChart });
 
       expect(form.find(selector.titleField).element.value).toEqual(emptyChart.title);
     });
@@ -309,18 +294,14 @@ describe('ChartForm.vue', () => {
 
       it('disables saving when required fields are missing', async () => {
         // delete the title
-        form.find(selector.titleField).setValue('');
-        await Vue.nextTick();
-
+        await form.find(selector.titleField).setValue('');
         expect(form.findAll(selector.validationError).length).toEqual(1);
         expect(form.find(selector.saveButton).attributes().disabled).toBeTruthy();
       });
 
       it('validates date formats', async () => {
         // enter an invalid date
-        form.find(selector.startDateField).setValue('02/30/2017');
-        await Vue.nextTick();
-
+        await form.find(selector.startDateField).setValue('02/30/2017');
         expect(form.findAll(selector.validationError).length).toEqual(1);
         expect(form.text()).toMatch('Dates must be MM/DD/YYYY format.');
         expect(form.find(selector.saveButton).attributes().disabled).toBeTruthy();
@@ -328,9 +309,7 @@ describe('ChartForm.vue', () => {
 
       it('validates chart end date formats', async () => {
         // enter an invalid date
-        form.find('input[name=chart_end_date]').setValue('02/30/2017');
-        await Vue.nextTick();
-
+        await form.find('input[name=chart_end_date]').setValue('02/30/2017');
         expect(form.findAll(selector.validationError).length).toEqual(1);
         expect(form.text()).toMatch('Dates must be MM/DD/YYYY format.');
         expect(form.find(selector.saveButton).attributes().disabled).toBeTruthy();
@@ -338,13 +317,11 @@ describe('ChartForm.vue', () => {
 
       it('disables saving when target date validation fails', async () => {
         // make a change to enable save button
-        form.find(selector.titleField).setValue('Test Title');
-        await Vue.nextTick();
+        await form.find(selector.titleField).setValue('Test Title');
         expect(form.find(selector.saveButton).attributes().disabled).toBeFalsy();
 
         // delete the start date, which is required when target is present
-        form.find(selector.startDateField).setValue('');
-        await Vue.nextTick();
+        await form.find(selector.startDateField).setValue('');
 
         // errors should disable save button
         expect(form.findAll(selector.validationError).length).toEqual(1);
@@ -353,15 +330,13 @@ describe('ChartForm.vue', () => {
 
       it('clears errors on cancel', async () => {
         // delete the title
-        form.find(selector.titleField).setValue('');
-        await Vue.nextTick();
+        await form.find(selector.titleField).setValue('');
 
         expect(form.findAll(selector.validationError).length).toEqual(1);
         expect(form.find(selector.saveButton).attributes().disabled).toBeTruthy();
 
         // click the cancel button
-        form.find(selector.cancelButton).trigger('click');
-        await Vue.nextTick();
+        await form.find(selector.cancelButton).trigger('click');
 
         expect(form.findAll(selector.validationError).length).toEqual(0);
       });
@@ -418,10 +393,9 @@ describe('ChartForm.vue', () => {
         `${selector.dateFieldEventSelect} > option`
       );
 
-      wrapper
+      await wrapper
         .find(selector.dateFieldEventSelect)
         .setValue(dateFieldEventOptions.at(1).element.value);
-      await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.model.field).toEqual('');
       const dateFieldOptions = wrapper.findAll(`${selector.dateFieldSelect} > option`);
@@ -448,10 +422,9 @@ describe('ChartForm.vue', () => {
         `${selector.groupFieldEventSelect} > option`
       );
 
-      wrapper
+      await wrapper
         .find(selector.groupFieldEventSelect)
         .setValue(groupFieldEventOptions.at(3).element.value);
-      await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.model.group).toEqual('');
       const groupFieldOptions = wrapper.findAll(
@@ -485,8 +458,7 @@ describe('ChartForm.vue', () => {
 
       it('disables saving when date field event is missing', async () => {
         // unselect the event
-        form.find(selector.dateFieldEventSelect).setValue('');
-        await Vue.nextTick();
+        await form.find(selector.dateFieldEventSelect).setValue('');
 
         // date event is invalid
         expect(form.findAll(selector.validationError).length).toEqual(1);
@@ -497,10 +469,9 @@ describe('ChartForm.vue', () => {
 
       it('validates date field event selected if date field selected', async () => {
         // Unselect date field event - select date field
-        form.find(selector.dateFieldEventSelect).setValue('');
+        await form.find(selector.dateFieldEventSelect).setValue('');
         const dateFieldOption = form.findAll(`${selector.dateFieldSelect} > option`).at(1);
-        form.find(selector.dateFieldSelect).setValue(dateFieldOption.element.value);
-        await Vue.nextTick();
+        await form.find(selector.dateFieldSelect).setValue(dateFieldOption.element.value);
 
         // date event and date field are invalid
         expect(form.findAll(selector.validationError).length).toEqual(2);
@@ -512,10 +483,9 @@ describe('ChartForm.vue', () => {
 
       it('validates group event selected if group selected', async () => {
         // Unselect group event - select group field
-        form.find(selector.groupFieldEventSelect).setValue('');
+        await form.find(selector.groupFieldEventSelect).setValue('');
         const groupFieldOption = form.findAll(`${selector.groupingFieldSelect} > option`).at(1);
-        form.find(selector.groupingFieldSelect).setValue(groupFieldOption.element.value);
-        await Vue.nextTick();
+        await form.find(selector.groupingFieldSelect).setValue(groupFieldOption.element.value);
 
         expect(form.findAll(selector.validationError).length).toEqual(1);
         expect(form.text()).toMatch(

--- a/test/components/ChartSummary_test.js
+++ b/test/components/ChartSummary_test.js
@@ -83,12 +83,12 @@ describe('ChartSummary.vue', () => {
       expect(buttons.length).toEqual(2);
     });
 
-    it('copies the table data when the link is clicked', () => {
+    it('copies the table data when the link is clicked', async () => {
       spyOn(wrapper.vm, 'copyTable');
 
       const table = wrapper.findAll('table').at(1);
       const button = table.find('a');
-      button.trigger('click');
+      await button.trigger('click');
 
       expect(wrapper.vm.copyTable).toHaveBeenCalledWith(wrapper.vm.$refs.groupedTable);
     });

--- a/test/components/Chart_test.js
+++ b/test/components/Chart_test.js
@@ -17,7 +17,7 @@ describe('Chart.vue', () => {
       const response = JSON.parse(exampleResponses.data.nonlongitudinal.responseText);
       let wrapper;
 
-      beforeEach(done => {
+      beforeEach(async () => {
         wrapper = shallowMount(Chart, {
           propsData: {
             canEdit: true,
@@ -33,7 +33,7 @@ describe('Chart.vue', () => {
           }
         });
 
-        wrapper.vm.dataPromise.then(() => done());
+        await wrapper.vm.dataPromise;
       });
 
       it('creates the chart container', () => {
@@ -95,7 +95,7 @@ describe('Chart.vue', () => {
       response.warnings = [{ key: 'noData', message: 'The filter returned 0 records.' }];
       let wrapper;
 
-      beforeEach(done => {
+      beforeEach(async () => {
         wrapper = shallowMount(Chart, {
           propsData: {
             canEdit: true,
@@ -111,7 +111,7 @@ describe('Chart.vue', () => {
           }
         });
 
-        wrapper.vm.dataPromise.then(() => done());
+        await wrapper.vm.dataPromise;
       });
 
       it('displays the warnings', () => {
@@ -127,7 +127,7 @@ describe('Chart.vue', () => {
       const response = JSON.parse(exampleResponses.data.longitudinal.responseText);
       let wrapper;
 
-      beforeEach(done => {
+      beforeEach(async () => {
         wrapper = shallowMount(Chart, {
           propsData: {
             canEdit: true,
@@ -143,7 +143,7 @@ describe('Chart.vue', () => {
           }
         });
 
-        wrapper.vm.dataPromise.then(() => done());
+        await wrapper.vm.dataPromise;
       });
 
       it('shows a title', () => {
@@ -204,7 +204,7 @@ describe('Chart.vue', () => {
       ];
       let wrapper;
 
-      beforeEach(done => {
+      beforeEach(async () => {
         wrapper = shallowMount(Chart, {
           propsData: {
             canEdit: true,
@@ -220,7 +220,7 @@ describe('Chart.vue', () => {
           }
         });
 
-        wrapper.vm.dataPromise.then(() => done());
+        await wrapper.vm.dataPromise;
       });
 
       it('displays the warnings', () => {
@@ -236,7 +236,7 @@ describe('Chart.vue', () => {
       );
       let wrapper;
 
-      beforeEach(done => {
+      beforeEach(async () => {
         wrapper = shallowMount(Chart, {
           propsData: {
             canEdit: true,
@@ -252,7 +252,7 @@ describe('Chart.vue', () => {
           }
         });
 
-        wrapper.vm.dataPromise.then(() => done());
+        await wrapper.vm.dataPromise;
       });
 
       it('shows live event filter', () => {
@@ -269,16 +269,14 @@ describe('Chart.vue', () => {
 
         // Select an event - data should change
         const visit1Option = wrapper.find('option[value=visit_1]');
-        wrapper.find('select').setValue(visit1Option.element.value);
-        await wrapper.vm.$nextTick();
+        await wrapper.find('select').setValue(visit1Option.element.value);
         expect(wrapper.vm.filteredData).not.toEqual(allEventData);
         expect(wrapper.vm.grouped).not.toEqual(allEventGrouped);
         expect(wrapper.vm.summary).not.toEqual(allEventSummary);
 
         // Select all events again - data should revert
         const allEventsOption = wrapper.findAll('option').at(0);
-        wrapper.find('select').setValue(allEventsOption.element.value);
-        await wrapper.vm.$nextTick();
+        await wrapper.find('select').setValue(allEventsOption.element.value);
         expect(wrapper.vm.filteredData).toEqual(allEventData);
         expect(wrapper.vm.grouped).toEqual(allEventGrouped);
         expect(wrapper.vm.summary).toEqual(allEventSummary);
@@ -290,7 +288,7 @@ describe('Chart.vue', () => {
     const response = JSON.parse(exampleResponses.data.longitudinal.responseText);
     let wrapper, dataService;
 
-    beforeEach(done => {
+    beforeEach(async () => {
       dataService = {
         getChartData() {
           return Promise.resolve(response);
@@ -308,16 +306,14 @@ describe('Chart.vue', () => {
         }
       });
 
-      wrapper.vm.dataPromise.then(() => done());
+      await wrapper.vm.dataPromise;
     });
 
-    it('refreshes chart data', done => {
+    it('refreshes chart data', async () => {
       spyOn(dataService, 'getChartData').and.callThrough();
-      wrapper.find('[data-description=reload]').trigger('click');
-      wrapper.vm.dataPromise.then(() => {
-        expect(dataService.getChartData).toHaveBeenCalled();
-        done();
-      });
+      await wrapper.find('[data-description=reload]').trigger('click');
+      await wrapper.vm.dataPromise;
+      expect(dataService.getChartData).toHaveBeenCalled();
     });
   });
 
@@ -325,7 +321,7 @@ describe('Chart.vue', () => {
     const response = JSON.parse(exampleResponses.data.longitudinal.responseText);
     let wrapper, dataService;
 
-    beforeEach(done => {
+    beforeEach(async () => {
       dataService = {
         getChartData() {
           return Promise.resolve(response);
@@ -343,19 +339,17 @@ describe('Chart.vue', () => {
         }
       });
 
-      wrapper.vm.dataPromise.then(() => done());
+      await wrapper.vm.dataPromise;
     });
 
-    it('refreshes chart data when chartDef is replaced', done => {
+    it('refreshes chart data when chartDef is replaced', async () => {
       const newChart = exampleLongitudinalChartDef('different');
 
       spyOn(dataService, 'getChartData').and.callThrough();
-      wrapper.setProps({ chartDef: newChart });
+      await wrapper.setProps({ chartDef: newChart });
 
-      wrapper.vm.dataPromise.then(() => {
-        expect(dataService.getChartData).toHaveBeenCalled();
-        done();
-      });
+      await wrapper.vm.dataPromise;
+      expect(dataService.getChartData).toHaveBeenCalled();
     });
   });
 
@@ -364,7 +358,7 @@ describe('Chart.vue', () => {
     let deleteSelector = '[data-description=delete]';
     let wrapper;
 
-    beforeEach(done => {
+    beforeEach(async () => {
       wrapper = shallowMount(Chart, {
         propsData: {
           canEdit: true,
@@ -380,26 +374,25 @@ describe('Chart.vue', () => {
         }
       });
 
-      wrapper.vm.dataPromise.then(() => done());
+      await wrapper.vm.dataPromise;;
     });
 
     it('is not shown if the user cannot edit', async () => {
       expect(wrapper.find(deleteSelector).exists()).toBe(true);
 
-      wrapper.setProps({ canEdit: false });
-      await Vue.nextTick();
+      await wrapper.setProps({ canEdit: false });
       expect(wrapper.find(deleteSelector).exists()).toBe(false);
     });
 
-    it('does not emit an event if not confirmed', () => {
+    it('does not emit an event if not confirmed', async () => {
       spyOn(window, 'confirm').and.returnValue(false);
-      wrapper.find(deleteSelector).trigger('click');
+      await wrapper.find(deleteSelector).trigger('click');
       expect(wrapper.emitted('delete-chart')).toBeFalsy();
     });
 
-    it('emits an event with the chart definition when confirmed', () => {
+    it('emits an event with the chart definition when confirmed', async () => {
       spyOn(window, 'confirm').and.returnValue(true);
-      wrapper.find(deleteSelector).trigger('click');
+      await wrapper.find(deleteSelector).trigger('click');
       expect(wrapper.emitted('delete-chart')).toBeTruthy();
       expect(wrapper.emitted('delete-chart')[0]).toEqual([exampleLongitudinalChart]);
     });
@@ -410,7 +403,7 @@ describe('Chart.vue', () => {
     const legendToggleSelector = '[data-description=toggle-legend]';
     let wrapper, chartDef;
 
-    beforeEach(done => {
+    beforeEach(async () => {
       chartDef = exampleLongitudinalChartDef();
       wrapper = shallowMount(Chart, {
         propsData: {
@@ -427,34 +420,32 @@ describe('Chart.vue', () => {
         }
       });
 
-      wrapper.vm.dataPromise.then(() => {
-        spyOn(wrapper.vm.chart, 'update').and.returnValue(undefined);
-        done();
-      });
+      await wrapper.vm.dataPromise;
+      spyOn(wrapper.vm.chart, 'update').and.returnValue(undefined);
     });
 
-    it('toggles the legend flag in the chart config', () => {
+    it('toggles the legend flag in the chart config', async () => {
       const chart = wrapper.vm.chart;
       expect(chart.config.options.legend.display).toBe(true);
 
-      wrapper.find(legendToggleSelector).trigger('click');
+      await wrapper.find(legendToggleSelector).trigger('click');
       expect(chart.config.options.legend.display).toBe(false);
     });
 
-    it('updates the chart', () => {
+    it('updates the chart', async () => {
       const chart = wrapper.vm.chart;
-      wrapper.find(legendToggleSelector).trigger('click');
+      await wrapper.find(legendToggleSelector).trigger('click');
       expect(chart.update).toHaveBeenCalled();
     });
 
-    it('does not emit an event if the user cannot edit', () => {
-      wrapper.setProps({ canEdit: false });
-      wrapper.find(legendToggleSelector).trigger('click');
+    it('does not emit an event if the user cannot edit', async () => {
+      await wrapper.setProps({ canEdit: false });
+      await wrapper.find(legendToggleSelector).trigger('click');
       expect(wrapper.emitted('toggle-legend')).toBeFalsy();
     });
 
-    it('emits an event with the chart definition when user can edit', () => {
-      wrapper.find(legendToggleSelector).trigger('click');
+    it('emits an event with the chart definition when user can edit', async () => {
+      await wrapper.find(legendToggleSelector).trigger('click');
       expect(wrapper.emitted('toggle-legend')).toBeTruthy();
       expect(wrapper.emitted('toggle-legend')[0]).toEqual([chartDef]);
     });


### PR DESCRIPTION
Update tests to `await` the result of all calls to `trigger`, `setValue`, and `setProps`, as described in the [documentation on testing asynchronous behavior](https://vue-test-utils.vuejs.org/guides/#testing-asynchronous-behavior). Fixes test failures after upgrade to `@vue/test-utils` 1.1.3.