### PR TITLE
REDDEV-749 Upgrade to Bootstrap 5

### DIFF
--- a/config.json
+++ b/config.json
@@ -35,7 +35,7 @@
     }
   ],
   "compatibility": {
-      "redcap-version-min": "8.5.4",
+      "redcap-version-min": "13.4.0",
       "redcap-version-max": ""
   },
   "permissions": [

--- a/js/components/Chart.vue
+++ b/js/components/Chart.vue
@@ -13,7 +13,7 @@
         <a
           :href="formIdSelector"
           role="button"
-          data-toggle="collapse"
+          data-bs-toggle="collapse"
           data-description="edit"
           v-if="canEdit"
         >
@@ -51,7 +51,7 @@
     <div class="row">
       <span class="vizr-event-select col-xs-3">
         <select
-          class="form-control form-control-sm"
+          class="form-control form-control-sm form-select"
           name="filter-event"
           v-if="hasMultipleEvents"
           v-model="selectedEvent"

--- a/js/components/ChartForm.vue
+++ b/js/components/ChartForm.vue
@@ -7,8 +7,8 @@
           href="#"
           class="remove-form pull-right float-right"
           role="button"
-          data-toggle="collapse"
-          :data-target="idSelector"
+          data-bs-toggle="collapse"
+          :data-bs-target="idSelector"
           aria-hidden="true"
           aria-expanded="true"
           @click="reset"
@@ -62,10 +62,10 @@
                 @input="dateFieldChanged"
               />
               <span
-                class="input-group-addon input-group-append"
+                class="input-group-text"
                 @click="showDatePicker($refs.startDateInput)"
               >
-                <span class="input-group-text"><i class="far fa-calendar-alt"></i></span>
+                <i class="far fa-calendar-alt"></i>
               </span>
             </div>
             <div class="help-block error-help">{{ errors.startError }}</div>
@@ -87,10 +87,10 @@
                 @input="dateFieldChanged"
               />
               <span
-                class="input-group-addon input-group-append"
+                class="input-group-text"
                 @click="showDatePicker($refs.endDateInput)"
               >
-                <span class="input-group-text"><i class="far fa-calendar-alt"></i></span>
+                <i class="far fa-calendar-alt"></i>
               </span>
             </div>
             <div class="help-block error-help">{{ errors.chartEndError }}</div>
@@ -107,7 +107,7 @@
             <select
               ref="dateFieldEventSelect"
               v-model="model.dateFieldEvent"
-              class="form-control form-control-sm"
+              class="form-control form-control-sm form-select"
               name="date_field_event"
               required="required"
               data-field="dateFieldEvent"
@@ -131,7 +131,7 @@
             </label>
             <select
               v-model="model.field"
-              class="form-control form-control-sm"
+              class="form-control form-control-sm form-select"
               name="record_date"
               required="required"
               data-validate="validateDateEvent"
@@ -154,7 +154,7 @@
             </label>
             <select
               v-model="model.dateInterval"
-              class="form-control form-control-sm"
+              class="form-control form-control-sm form-select"
               name="date_interval"
               required="required"
               data-field="dateInterval"
@@ -197,7 +197,7 @@
               {{ messages.groupingFieldEventLabel }}
             </label>
             <select
-              class="form-control form-control-sm"
+              class="form-control form-control-sm form-select"
               name="group_field_event"
               data-field="groupFieldEvent"
               ref="groupFieldEventSelect"
@@ -221,7 +221,7 @@
             </label>
             <select
               v-model="model.group"
-              class="form-control form-control-sm"
+              class="form-control form-control-sm form-select"
               name="group_field"
               data-validate="validateGroup"
               data-field="group"
@@ -259,7 +259,7 @@
           <div class="form-group targets" v-else>
             <label>{{ messages.targetCountsLabel }}</label>
             <a
-              data-toggle="collapse"
+              data-bs-toggle="collapse"
               role="button"
               :href="groupTargetsIdSelector"
               aria-expanded="true"
@@ -307,10 +307,10 @@
                 @input="dateFieldChanged"
               />
               <span
-                class="input-group-addon input-group-append"
+                class="input-group-text"
                 @click="showDatePicker($refs.targetEndDateInput)"
               >
-                <span class="input-group-text"><i class="far fa-calendar-alt"></i></span>
+                <i class="far fa-calendar-alt"></i>
               </span>
             </div>
             <div class="help-block error-help">{{ errors.endError }}</div>
@@ -325,8 +325,8 @@
           type="submit"
           class="btn btn-primary"
           name="submit_vizr_form"
-          data-toggle="collapse"
-          :data-target="idSelector"
+          data-bs-toggle="collapse"
+          :data-bs-target="idSelector"
           :disabled="submitDisabled"
           aria-expanded="true"
           @click="save"
@@ -336,8 +336,8 @@
         <button
           type="cancel"
           class="btn btn-link"
-          data-toggle="collapse"
-          :data-target="idSelector"
+          data-bs-toggle="collapse"
+          :data-bs-target="idSelector"
           aria-expanded="true"
           @click="reset"
         >

--- a/js/components/Instructions.vue
+++ b/js/components/Instructions.vue
@@ -12,8 +12,8 @@
     <li>
       <a
         href="#"
-        data-toggle="collapse"
-        data-target="#collapseMore"
+        data-bs-toggle="collapse"
+        data-bs-target="#collapseMore"
         aria-expanded="false"
         aria-controls="collapseMore"
       >

--- a/js/components/Vizr.vue
+++ b/js/components/Vizr.vue
@@ -30,8 +30,8 @@
         <button
           type="button"
           class="btn btn-warning"
-          data-toggle="collapse"
-          data-target=".add-chart-form"
+          data-bs-toggle="collapse"
+          data-bs-target=".add-chart-form"
           aria-expanded="false"
           aria-controls="add-chart-form"
           :disabled="hasConfigError"

--- a/lib/metadata.php
+++ b/lib/metadata.php
@@ -42,11 +42,6 @@ if (REDCap::isLongitudinal()) {
 $metadata_object->recordIdField = $record_id_field;
 $metadata_object->dataDictionary = $data_dictionary;
 $metadata_object->events = $event_map;
-if (REDCap::versionCompare ( REDCAP_VERSION , '8.7.1', '<')) {
-	$metadata_object->bootstrapVersion = 3;
-} else {
-	$metadata_object->bootstrapVersion = 4;
-}
 
 print json_encode($metadata_object);
 


### PR DESCRIPTION
Make changes needed to upgrade to Bootstrap 5, introduced in REDCap 13.4.0:

* Use `data-bs-` attributes for JS integration
* Fix styling of form `<select>` inputs
* Fix styling of calendar input addons
* Bump minimum REDCap version

![localhost_redcap_redcap_v13 9 2_ExternalModules__prefix=vizr page=index pid=17 (1)](https://github.com/OCTRI/REDCap-Vizr/assets/2746306/a6cfaa44-1b2b-485c-83cd-e9b43cdeb76d)
